### PR TITLE
♻️ Improve handling of API key

### DIFF
--- a/Sources/GoogleGenerativeAI/GenerativeLanguage.swift
+++ b/Sources/GoogleGenerativeAI/GenerativeLanguage.swift
@@ -17,14 +17,14 @@ import Get
 
 /// The API client for the PaLM API.
 public class GenerativeLanguage {
-  
+
   private(set) var apiKey: String
 
   private lazy var apiClient: APIClient = {
     let baseURL = URL(string: "https://generativelanguage.googleapis.com")!
     return APIClient(baseURL: baseURL) { configuration in
-      configuration.delegate = self
       configuration.sessionConfiguration.httpAdditionalHeaders = ["x-goog-api-client": "genai-swift/0.1.0"]
+      configuration.sessionConfiguration.httpAdditionalHeaders = ["x-goog-api-key": apiKey]
     }
   }()
 
@@ -35,12 +35,6 @@ public class GenerativeLanguage {
   /// - Parameter apiKey: The API key to use.
   public init(apiKey: String) {
     self.apiKey = apiKey
-  }
-}
-
-extension GenerativeLanguage: APIClientDelegate {
-  public func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
-    request.url?.append(queryItems: [URLQueryItem(name: "key", value: apiKey)])
   }
 }
 


### PR DESCRIPTION
* No longer use a delegate, which makes the interface cleaner. 
* API keys are now being sent as an additional HTTP header.