### PR TITLE
[FIX] Modify swift version to 5.7.1 and fix test build error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7.1
 
 // Copyright 2023 Google LLC
 //

--- a/Tests/GoogleGenerativeAITests/GoogleGenerativeAITests.swift
+++ b/Tests/GoogleGenerativeAITests/GoogleGenerativeAITests.swift
@@ -16,35 +16,35 @@ import XCTest
 @testable import GoogleGenerativeAI
 
 final class GenerativeLanguageTests: XCTestCase {
-    let apiKey = "<INSERT-YOUR-API-KEY>"
+  let apiKey = "<INSERT-YOUR-API-KEY>"
+
+  func testSetup() {
+    let client = GenerativeLanguage(apiKey: apiKey)
     
-    func testSetup() {
-        let client = GenerativeLanguage(apiKey: apiKey)
-        
-        XCTAssertNotNil(client)
-        XCTAssertEqual(client.apiKey, apiKey)
-    }
-    
-    func testGenerateMessage() async throws {
-        let client = GenerativeLanguage(apiKey: apiKey)
-        let model = "models/chat-bison-001"
-        
-        let result = try await client.generateText(with: "Say something nice", model: model)
-        print(result)
-    }
-    
-    func testListModels() async throws {
-        let client = GenerativeLanguage(apiKey: apiKey)
-        
-        let result = try await client.listModels()
-        print(result.models ?? [])
-    }
-    
-    func testGetModel() async throws {
-        let client = GenerativeLanguage(apiKey: apiKey)
-        let model = "chat-bison-001"
-        
-        let result = try await client.getModel(name: model)
-        print(result.displayName ?? [])
-    }
+    XCTAssertNotNil(client)
+    XCTAssertEqual(client.apiKey, apiKey)
+  }
+
+  func testGenerateMessage() async throws {
+    let client = GenerativeLanguage(apiKey: apiKey)
+    let model = "models/chat-bison-001"
+
+    let result = try await client.generateText(with: "Say something nice", model: model)
+    print(result)
+  }
+
+  func testListModels() async throws {
+    let client = GenerativeLanguage(apiKey: apiKey)
+
+    let result = try await client.listModels()
+    print(result.models ?? [])
+  }
+
+  func testGetModel() async throws {
+    let client = GenerativeLanguage(apiKey: apiKey)
+    let model = "chat-bison-001"
+
+    let result = try await client.getModel(name: model)
+    print(result.displayName ?? [])
+  }
 }

--- a/Tests/GoogleGenerativeAITests/GoogleGenerativeAITests.swift
+++ b/Tests/GoogleGenerativeAITests/GoogleGenerativeAITests.swift
@@ -16,35 +16,35 @@ import XCTest
 @testable import GoogleGenerativeAI
 
 final class GenerativeLanguageTests: XCTestCase {
-  let apiKey = "<INSERT-YOUR-API-KEY>"
-  
-  func testSetup() {
-    let client = GenerativeLanguage(apiKey: apiKey)
-
-    XCTAssertNotNil(client)
-    XCTAssertEqual(client.apiKey, apiKey)
-  }
-
-  func testGenerateMessage() async throws {
-    let client = GenerativeLanguage(apiKey: apiKey)
-    let model = "models/chat-bison-001"
-
-    let result = try await client.generateMessage(with: "Say something nice", model: model)
-    print(result)
-  }
-
-  func testListModels() async throws {
-    let client = GenerativeLanguage(apiKey: apiKey)
-
-    let result = try await client.listModels()
-    print(result?.models)
-  }
-
-  func testGetModel() async throws {
-    let client = GenerativeLanguage(apiKey: apiKey)
-    let model = "chat-bison-001"
-
-    let result = try await client.getModel(name: model)
-    print(result?.displayName)
-  }
+    let apiKey = "<INSERT-YOUR-API-KEY>"
+    
+    func testSetup() {
+        let client = GenerativeLanguage(apiKey: apiKey)
+        
+        XCTAssertNotNil(client)
+        XCTAssertEqual(client.apiKey, apiKey)
+    }
+    
+    func testGenerateMessage() async throws {
+        let client = GenerativeLanguage(apiKey: apiKey)
+        let model = "models/chat-bison-001"
+        
+        let result = try await client.generateText(with: "Say something nice", model: model)
+        print(result)
+    }
+    
+    func testListModels() async throws {
+        let client = GenerativeLanguage(apiKey: apiKey)
+        
+        let result = try await client.listModels()
+        print(result.models ?? [])
+    }
+    
+    func testGetModel() async throws {
+        let client = GenerativeLanguage(apiKey: apiKey)
+        let model = "chat-bison-001"
+        
+        let result = try await client.getModel(name: model)
+        print(result.displayName ?? [])
+    }
 }


### PR DESCRIPTION
1. Since April, the apps and SDKs must be built in Xcode 14.1 + to submit to the AppStore. To support Xcode 14.1, I modified the swift version to **5.7.1** from 5.8.0
> Reference: [developer.apple.com/ios/submit](https://developer.apple.com/ios/submit/#:~:text=Build%20with,iOS%2016.1%20SDK.)
2. I fixed the build errors on the tests.