### PR TITLE
[FIX] Removed force unwrapping that is not required

### DIFF
--- a/Sources/GoogleGenerativeAI/GenerativeLanguage.swift
+++ b/Sources/GoogleGenerativeAI/GenerativeLanguage.swift
@@ -21,7 +21,7 @@ public class GenerativeLanguage {
   private(set) var apiKey: String
 
   private lazy var apiClient: APIClient = {
-    let baseURL = URL(string: "https://generativelanguage.googleapis.com")!
+    let baseURL = URL(string: "https://generativelanguage.googleapis.com")
     return APIClient(baseURL: baseURL) { configuration in
       configuration.sessionConfiguration.httpAdditionalHeaders = ["x-goog-api-client": "genai-swift/0.1.0"]
       configuration.sessionConfiguration.httpAdditionalHeaders = ["x-goog-api-key": apiKey]


### PR DESCRIPTION
Based on the logic, the `APIClient` creates a `Configuration` object in its initializer, and both of them receive the baseURL as an *optional* type, so force-unwrapping is not *necessary* while creating the `APIClient` instance.

I removed the `!` and checked that it builds well.
