### PR TITLE
Automatically add and remove specific labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+'status:awaiting review':
+- '**/*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "PR Labeler"
+
+on:
+  pull_request_target:
+    types: ["opened", "reopened", "ready_for_review"]
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+    if: ${{ github.event.pull_request.draft == false }}

--- a/.github/workflows/remove-issue-labels.yml
+++ b/.github/workflows/remove-issue-labels.yml
@@ -1,0 +1,18 @@
+name: Remove issue labels
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  remove_label:
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        labels: |
+          status:triaged
+          status:more data needed

--- a/.github/workflows/remove-pr-labels.yml
+++ b/.github/workflows/remove-pr-labels.yml
@@ -1,0 +1,18 @@
+name: Remove PR Labels
+
+on:
+  pull_request_target:
+    types: ["closed", "merged"]
+
+jobs:
+  remove_label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        labels: |
+          status:awaiting review
+          status:awaiting user response


### PR DESCRIPTION
1. Add "awaiting-review" to all opened PRs
2. Remove "status:X" labels when an issue is closed
3. Remove "status:X" labels when a PR is closed

cc @google/gtech-llm-support 