### PR TITLE
Added `API.V1beta2.Resource` to handle the path and request ID

### DIFF
--- a/Sources/GoogleGenerativeAI/Endpoints.swift
+++ b/Sources/GoogleGenerativeAI/Endpoints.swift
@@ -24,12 +24,23 @@ extension API {
   struct V1beta2 {
     /// Path: `/v1beta2`
     let path: String
+      
+    enum Resource: String, Identifiable {
+      case generateMessage
+      case generateText
+      case embedText
+      case list
+      case get
+          
+      var baseID: String { "generativelanguage.models" }
+      var id: String { "\(baseID).\(self.rawValue)" }
+    }
   }
 }
 
 extension API.V1beta2 {
   func generateMessage(_ model: String) -> GenerateMessageResource {
-    GenerateMessageResource(path: "\(path)/\(model):generateMessage")
+    GenerateMessageResource(path: "\(path)/\(model):\(Resource.generateMessage.rawValue)")
   }
 
   struct GenerateMessageResource {
@@ -38,14 +49,14 @@ extension API.V1beta2 {
 
     /// Generates a response from the model given an input `MessagePrompt`.
     func post(_ body: GenerateMessageRequest? = nil) -> Request<GenerateMessageResponse> {
-      Request(path: path, method: .post, body: body, id: "generativelanguage.models.generateMessage")
+      Request(path: path, method: .post, body: body, id: Resource.generateMessage.id)
     }
   }
 }
 
 extension API.V1beta2 {
   func generateText(_ model: String) -> GenerateTextResource {
-    GenerateTextResource(path: "\(path)/\(model):generateText")
+    GenerateTextResource(path: "\(path)/\(model):\(Resource.generateText.rawValue)")
   }
 
   struct GenerateTextResource {
@@ -54,14 +65,14 @@ extension API.V1beta2 {
 
     /// Generates a response from the model given an input `MessagePrompt`.
     func post(_ body: GenerateTextRequest? = nil) -> Request<GenerateTextResponse> {
-      Request(path: path, method: .post, body: body, id: "generativelanguage.models.generateText")
+      Request(path: path, method: .post, body: body, id: Resource.generateText.id)
     }
   }
 }
 
 extension API.V1beta2 {
   func embedText(_ model: String) -> EmbedTextResource {
-    EmbedTextResource(path: "\(path)/\(model):embedText")
+    EmbedTextResource(path: "\(path)/\(model):\(Resource.embedText.rawValue)")
   }
 
   struct EmbedTextResource {
@@ -70,7 +81,7 @@ extension API.V1beta2 {
 
     /// Generates a response from the model given an input `MessagePrompt`.
     func post(_ body: EmbedTextRequest? = nil) -> Request<EmbedTextResponse> {
-      Request(path: path, method: .post, body: body, id: "generativelanguage.models.embedText")
+      Request(path: path, method: .post, body: body, id: Resource.embedText.id)
     }
   }
 }
@@ -87,13 +98,13 @@ extension API.V1beta2 {
 
     /// Lists models available through the API.
     func get(parameters: Parameters? = nil) -> Request<ListModelsResponse> {
-      Request(path: path, method: .get, query: parameters?.asQuery, id: "generativelanguage.models.list")
+      Request(path: path, method: .get, query: parameters?.asQuery, id: Resource.list.id)
     }
 
     /// Gets information about a specific Model.
     func get(name: String) -> Request<Model> {
       let modelPath = path.appending("/\(name)")
-      return Request(path: modelPath, method: .get, id: "generativelanguage.models.get")
+      return Request(path: modelPath, method: .get, id: Resource.get.id)
     }
 
     struct Parameters {

--- a/Sources/GoogleGenerativeAI/Endpoints.swift
+++ b/Sources/GoogleGenerativeAI/Endpoints.swift
@@ -32,7 +32,7 @@ extension API {
       case list
       case get
           
-      var baseID: String { "generativelanguage.models" }
+      private var baseID: String { "generativelanguage.models" }
       var id: String { "\(baseID).\(self.rawValue)" }
     }
   }

--- a/Sources/OpenAPI/Extensions/StringCodingKey.swift
+++ b/Sources/OpenAPI/Extensions/StringCodingKey.swift
@@ -19,9 +19,9 @@ import Foundation
 
 struct StringCodingKey: CodingKey, ExpressibleByStringLiteral {
   private let string: String
-  private var int: Int?
+  private let int: Int?
 
-  var stringValue: String { return string }
+  var stringValue: String { string }
 
   init(string: String) {
     self.string = string
@@ -31,7 +31,7 @@ struct StringCodingKey: CodingKey, ExpressibleByStringLiteral {
     self.string = stringValue
   }
 
-  var intValue: Int? { return int }
+  var intValue: Int? { int }
 
   init?(intValue: Int) {
     self.string = String(describing: intValue)

--- a/Sources/OpenAPI/Extensions/StringCodingKey.swift
+++ b/Sources/OpenAPI/Extensions/StringCodingKey.swift
@@ -19,7 +19,7 @@ import Foundation
 
 struct StringCodingKey: CodingKey, ExpressibleByStringLiteral {
   private let string: String
-  private let int: Int?
+  private var int: Int?
 
   var stringValue: String { string }
 


### PR DESCRIPTION
## Description of the change

```swift
  func generateMessage(_ model: String) -> GenerateMessageResource {
    - GenerateMessageResource(path: "\(path)/\(model):generateMessage")
    + GenerateMessageResource(path: "\(path)/\(model):\(Resource.generateMessage.rawValue)")
  }

  struct GenerateMessageResource {
    func post(_ body: GenerateMessageRequest? = nil) -> Request<GenerateMessageResponse> {
      - Request(path: path, method: .post, body: body, id: "generativelanguage.models.generateMessage")
      + Request(path: path, method: .post, body: body, id: Resource.generateMessage.id)
    }
  }
``` 

## Motivation
I added an `Enum` called `Resource` in `API.V1beta2` to manage frequently used string values.

## Type of change
Other - Improvement

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
