### PR TITLE
Fix DocC warnings when running `swift package generate-documentation`

### DIFF
--- a/Sources/GoogleAI/GenerationConfig.swift
+++ b/Sources/GoogleAI/GenerationConfig.swift
@@ -57,7 +57,7 @@ public struct GenerationConfig: Encodable {
   /// (unbounded).
   public let maxOutputTokens: Int?
 
-  /// A set of up to 5 ``String``s that will stop output generation. If
+  /// A set of up to 5 `String`s that will stop output generation. If
   /// specified, the API will stop at the first appearance of a stop sequence.
   /// The stop sequence will not be included as part of the response.
   public let stopSequences: [String]?

--- a/Sources/GoogleAI/Safety.swift
+++ b/Sources/GoogleAI/Safety.swift
@@ -19,7 +19,7 @@ import Foundation
 /// responses that exceed a certain threshold.
 public struct SafetyRating: Decodable, Equatable {
   /// The category describing the potential harm a piece of content may pose. See
-  /// ``SafetySetting.HarmCategory`` for a list of possible values.
+  /// ``SafetySetting/HarmCategory`` for a list of possible values.
   public let category: SafetySetting.HarmCategory
 
   /// The model-generated probability that a given piece of content falls under the harm category


### PR DESCRIPTION
Fixed the following warnings:
- `Sources/GoogleAI/GenerationConfig.swift:60:26: warning: 'String' doesn't exist at '/GoogleGenerativeAI/GenerationConfig/stopSequences'`
  - Shouldn't use double backticks because `String` isn't a type provided by our library
- `Sources/GoogleAI/Safety.swift:22:9: warning: 'SafetySetting.HarmCategory' doesn't exist at '/GoogleGenerativeAI/SafetyRating/category'`
  - DocC references use `/` instead of `.` for nested types