### PR TITLE
Add SPI Manifest for DocC documentation generation / hosting

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [GoogleGenerativeAI]


### PR DESCRIPTION
Added a Swift Package Index Manifest `.spi.yml` file so that DocC documentation is generated for the SDK and hosted at https://swiftpackageindex.com/google/generative-ai-swift. Configured to generate docs for iOS, rather than the default of macOS.

More Info: [Host DocC documentation in the Swift Package Index](https://swiftpackageindex.com/swiftpackageindex/spimanifest/1.1.1/documentation/spimanifest/commonusecases#Host-DocC-documentation-in-the-Swift-Package-Index)