### PR TITLE
Make `SafetyRating` conform to `Hashable`

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
@@ -16,13 +16,6 @@ import GoogleGenerativeAI
 import MarkdownUI
 import SwiftUI
 
-extension SafetyRating: Hashable {
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(category)
-    hasher.combine(probability)
-  }
-}
-
 extension SafetySetting.HarmCategory: CustomStringConvertible {
   public var description: String {
     switch self {

--- a/Sources/GoogleAI/Safety.swift
+++ b/Sources/GoogleAI/Safety.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A type defining potentially harmful media categories and their model-assigned ratings. A value
 /// of this type may be assigned to a category for every model-generated response, not just
 /// responses that exceed a certain threshold.
-public struct SafetyRating: Decodable, Equatable {
+public struct SafetyRating: Decodable, Equatable, Hashable {
   /// The category describing the potential harm a piece of content may pose. See
   /// ``SafetySetting/HarmCategory`` for a list of possible values.
   public let category: SafetySetting.HarmCategory


### PR DESCRIPTION
This allows collections of `SafetyRating`s to be displayed in SwiftUI views, such as [`List`](https://developer.apple.com/documentation/swiftui/list), which require the elements to conform to [`Hashable`](https://developer.apple.com/documentation/swift/hashable).

Note: When moved into the SDK, the auto-synthesized `Hashable` conformance can be used ([SE-0185](https://github.com/apple/swift-evolution/blob/main/proposals/0185-synthesize-equatable-hashable.md)). This wasn't possible when conformance was implemented in the sample app (`Extension outside of file declaring struct 'SafetyRating' prevents automatic synthesis of 'hash(into:)' for protocol 'Hashable'`).