### PR TITLE
Set "Google" as the author on Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,6 @@
 version: 1
+metadata:
+  authors: "Google"
 builder:
   configs:
     - platform: ios


### PR DESCRIPTION
Sets the author to "Google" for the [generative-ai-swift package](https://swiftpackageindex.com/google/generative-ai-swift) on Swift Package Index.