### PR TITLE
Fix background color of system chat bubble

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
@@ -46,7 +46,7 @@ struct MessageContentView: View {
         .markdownTextStyle {
           FontFamilyVariant(.normal)
           FontSize(.em(0.85))
-          ForegroundColor(.white)
+          ForegroundColor(message.participant == .system ? .black : .white)
         }
         .markdownBlockStyle(\.codeBlock) { configuration in
           configuration.label
@@ -75,8 +75,8 @@ struct MessageView: View {
       }
       MessageContentView(message: message)
         .padding(10)
-        .background(.blue)
-        .foregroundColor(.white)
+        .background(message.participant == .system  ? .gray.opacity(0.25) : .blue)
+        .foregroundColor(message.participant == .system ? .black : .white)
         .roundedCorner(10,
                        corners: [
                          .topLeft,

--- a/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
@@ -75,7 +75,7 @@ struct MessageView: View {
       }
       MessageContentView(message: message)
         .padding(10)
-        .background(message.participant == .system  ? .gray.opacity(0.25) : .blue)
+        .background(message.participant == .system ? .gray.opacity(0.25) : .blue)
         .foregroundColor(message.participant == .system ? .black : .white)
         .roundedCorner(10,
                        corners: [


### PR DESCRIPTION
## Description of the change
Show system chat bubbles in gray to distinguish from user chat bubbles in blue

## Motivation
Differentiates system and user chat bubbles

## Type of change
Bug fix 

