### PR TITLE
Fix colors of chat bubbles so they work in light and dark mode

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
@@ -46,7 +46,7 @@ struct MessageContentView: View {
         .markdownTextStyle {
           FontFamilyVariant(.normal)
           FontSize(.em(0.85))
-          ForegroundColor(message.participant == .system ? .black : .white)
+          ForegroundColor(message.participant == .system ? Color(UIColor.label) : .white)
         }
         .markdownBlockStyle(\.codeBlock) { configuration in
           configuration.label
@@ -75,8 +75,7 @@ struct MessageView: View {
       }
       MessageContentView(message: message)
         .padding(10)
-        .background(message.participant == .system ? .gray.opacity(0.25) : .blue)
-        .foregroundColor(message.participant == .system ? .black : .white)
+        .background(message.participant == .system ? Color(UIColor.systemFill) : Color(UIColor.systemBlue))
         .roundedCorner(10,
                        corners: [
                          .topLeft,

--- a/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/MessageView.swift
@@ -75,7 +75,9 @@ struct MessageView: View {
       }
       MessageContentView(message: message)
         .padding(10)
-        .background(message.participant == .system ? Color(UIColor.systemFill) : Color(UIColor.systemBlue))
+        .background(message.participant == .system
+          ? Color(UIColor.systemFill)
+          : Color(UIColor.systemBlue))
         .roundedCorner(10,
                        corners: [
                          .topLeft,


### PR DESCRIPTION
## Description of the change
Use system colors to ensure chat bubbles have enough contrast both in light and dark mode.

![CleanShot 2023-12-13 at 09 36 26@2x](https://github.com/google/generative-ai-swift/assets/232107/75084106-7543-4103-bad3-07c14d9019d0)

This fixes #51 .

## Type of change
Choose one: Bug fix

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
