### PR TITLE
Set scheme to `generative-ai-swift` in `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -5,3 +5,4 @@ builder:
   configs:
     - platform: ios
       documentation_targets: [GoogleGenerativeAI]
+      scheme: generative-ai-swift


### PR DESCRIPTION
The [build log](https://swiftpackageindex.com/builds/B3735E2E-96D3-4203-A704-49784C5F167A) on Swift Package Index shows `xcodebuild: error: The workspace named "spi-builder-workspace" does not contain a scheme named "GoogleGenerativeAI". The "-list" option can be used to find the names of the schemes in the workspace.`.

Manually setting the scheme to `generative-ai-swift` (found with `xcodebuild -list`) to see if this resolves the documentation generation failure.