### PR TITLE
Fix MIME type to "image/png" in `ModelContent.png(_:)`

### DIFF
--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -46,7 +46,7 @@ public struct ModelContent: Codable, Equatable {
 
     /// Convenience function for populating a Part with PNG data.
     public static func png(_ data: Data) -> Self {
-      return .data(mimetype: "image/jpeg", data)
+      return .data(mimetype: "image/png", data)
     }
 
     // MARK: Codable Conformance


### PR DESCRIPTION
The MIME type was erroneously being set to `"image/jpeg"` in the `ModelContent.png(_:)` convenience method.

Note: PNG images seem (in my limited testing) to be parsed correctly by the backend, even when the MIME type is set to `"image/jpeg"`.