### PR TITLE
Fix missing dependency for ChatSample

### DIFF
--- a/Examples/GenerativeAISample/GenerativeAISample.xcodeproj/project.pbxproj
+++ b/Examples/GenerativeAISample/GenerativeAISample.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		88E10F5E2B11140200C08E95 /* GenerativeAI-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 88209C142B0F928F00F64795 /* GenerativeAI-Info.plist */; };
 		88E10F5F2B11140500C08E95 /* APIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88209C192B0FBDC300F64795 /* APIKey.swift */; };
 		88E10F612B11162B00C08E95 /* GoogleGenerativeAI in Frameworks */ = {isa = PBXBuildFile; productRef = 88E10F602B11162B00C08E95 /* GoogleGenerativeAI */; };
+		CB0DFFD52B2B4F08006E109D /* GenerativeAIUIComponents in Frameworks */ = {isa = PBXBuildFile; productRef = CB0DFFD42B2B4F08006E109D /* GenerativeAIUIComponents */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -132,6 +133,7 @@
 			files = (
 				88E10F612B11162B00C08E95 /* GoogleGenerativeAI in Frameworks */,
 				88D9474D2B14F27E008B5580 /* MarkdownUI in Frameworks */,
+				CB0DFFD52B2B4F08006E109D /* GenerativeAIUIComponents in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -415,6 +417,7 @@
 			packageProductDependencies = (
 				88E10F602B11162B00C08E95 /* GoogleGenerativeAI */,
 				88D9474C2B14F27E008B5580 /* MarkdownUI */,
+				CB0DFFD42B2B4F08006E109D /* GenerativeAIUIComponents */,
 			);
 			productName = ChatSample;
 			productReference = 88E10F422B110D5300C08E95 /* ChatSample.app */;
@@ -1138,6 +1141,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 88209C212B0FBDF700F64795 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 			productName = GoogleGenerativeAI;
+		};
+		CB0DFFD42B2B4F08006E109D /* GenerativeAIUIComponents */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GenerativeAIUIComponents;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
## Description of the change
Fixed a problem in which GenerativeAIUIComponents was missing from the dependency on ChatSample and this sample app could not be built.

![スクリーンショット 2023-12-14 23 54 39](https://github.com/google/generative-ai-swift/assets/13805382/12f60095-c814-41df-9c75-f4e678db65e7)

|Before|After|
|:-:|:-:|
|![スクリーンショット 2023-12-14 23 55 59](https://github.com/google/generative-ai-swift/assets/13805382/9f28baea-b189-4369-ba68-629b262172d5)|![スクリーンショット 2023-12-14 23 56 46](https://github.com/google/generative-ai-swift/assets/13805382/ee87a254-8a85-48f8-8c9f-a29b793481c3)|

## Type of change
Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
