### PR TITLE
Set the scheme for the documentation build

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,5 +4,5 @@ metadata:
 builder:
   configs:
     - platform: ios
-      documentation_targets: [GoogleGenerativeAI]
+      documentation_targets: [generative-ai-swift]
       scheme: generative-ai-swift


### PR DESCRIPTION
## Description of the change
If there's one library the scheme matches the package, otherwise it auto-generates one for the package and generates a scheme for each product

## Motivation
Fix failing spi doc build: https://swiftpackageindex.com/builds/FDA7B1D2-9174-4546-938F-30058E60E466

## Type of change
Choose one: Bug fix
