### PR TITLE
Add support for Mac Catalyst

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -14,7 +14,7 @@ jobs:
   swift-build-run:
     strategy:
       matrix:
-        target: [iOS, macOS]
+        target: [iOS, macOS, catalyst]
         os: [macos-13]
         include:
           - os: macos-13

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
   platforms: [
     .iOS(.v15),
     .macOS(.v12),
+    .macCatalyst(.v15),
   ],
   products: [
     // Products define the executables and libraries a package produces, making them visible to

--- a/Sources/GoogleAI/PartsRepresentable.swift
+++ b/Sources/GoogleAI/PartsRepresentable.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(AppKit)
-  import AppKit // For NSImage extensions.
-#elseif canImport(UIKit)
+#if canImport(UIKit)
   import UIKit // For UIImage extensions.
+#elseif canImport(AppKit)
+  import AppKit // For NSImage extensions.
 #endif
 
 /// A protocol describing any data that could be interpreted as model input data.
@@ -46,7 +46,20 @@ extension [any PartsRepresentable]: PartsRepresentable {
   }
 }
 
-#if canImport(AppKit)
+#if canImport(UIKit)
+  /// Enables images to be representable as ``PartsRepresentable``.
+  extension UIImage: PartsRepresentable {
+    public var partsValue: [ModelContent.Part] {
+      guard let data = jpegData(compressionQuality: 0.8) else {
+        Logging.default.error("[GoogleGenerativeAI] Couldn't create JPEG from UIImage.")
+        return []
+      }
+
+      return [ModelContent.Part.data(mimetype: "image/jpeg", data)]
+    }
+  }
+
+#elseif canImport(AppKit)
   /// Enables images to be representable as ``PartsRepresentable``.
   extension NSImage: PartsRepresentable {
     public var partsValue: [ModelContent.Part] {
@@ -63,18 +76,4 @@ extension [any PartsRepresentable]: PartsRepresentable {
       return [ModelContent.Part.data(mimetype: "image/jpeg", data)]
     }
   }
-
-#elseif canImport(UIKit)
-  /// Enables images to be representable as ``PartsRepresentable``.
-  extension UIImage: PartsRepresentable {
-    public var partsValue: [ModelContent.Part] {
-      guard let data = jpegData(compressionQuality: 0.8) else {
-        Logging.default.error("[GoogleGenerativeAI] Couldn't create JPEG from UIImage.")
-        return []
-      }
-
-      return [ModelContent.Part.data(mimetype: "image/jpeg", data)]
-    }
-  }
-
 #endif

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -62,12 +62,7 @@ final class GoogleGenerativeAITests: XCTestCase {
     let _ = try await genAI.generateContent(str)
     let _ = try await genAI.generateContent([str])
     let _ = try await genAI.generateContent(str, "abc", "def")
-    #if canImport(AppKit)
-      _ = try await genAI.generateContent(NSImage())
-      _ = try await genAI.generateContent([NSImage()])
-      _ = try await genAI.generateContent(str, NSImage(), "def", NSImage())
-      _ = try await genAI.generateContent([str, NSImage(), "def", NSImage()])
-    #elseif canImport(UIKit)
+    #if canImport(UIKit)
       _ = try await genAI.generateContent(UIImage())
       _ = try await genAI.generateContent([UIImage()])
       _ = try await genAI
@@ -76,6 +71,11 @@ final class GoogleGenerativeAITests: XCTestCase {
       _ = try await genAI.generateContent([str, UIImage(), "def", UIImage()])
       _ = try await genAI.generateContent([ModelContent("def", UIImage()),
                                            ModelContent("def", UIImage())])
+    #elseif canImport(AppKit)
+      _ = try await genAI.generateContent(NSImage())
+      _ = try await genAI.generateContent([NSImage()])
+      _ = try await genAI.generateContent(str, NSImage(), "def", NSImage())
+      _ = try await genAI.generateContent([str, NSImage(), "def", NSImage()])
     #endif
 
     // PartsRepresentable combinations.
@@ -91,7 +91,19 @@ final class GoogleGenerativeAITests: XCTestCase {
       mimetype: "foo",
       Data()
     )] as [any PartsRepresentable])
-    #if canImport(AppKit)
+    #if canImport(UIKit)
+      _ = ModelContent(role: "user", parts: UIImage())
+      _ = ModelContent(role: "user", parts: [UIImage()])
+      // Note: without `as [any PartsRepresentable]` this will fail to compile with "Cannot convert
+      // value of type `[Any]` to expected type `[any PartsRepresentable]`. Not sure if there's a
+      // way we can get it to work.
+      _ = ModelContent(parts: [str, UIImage()] as [any PartsRepresentable])
+      // Alternatively, you can explicitly declare the type in a variable and pass it in.
+      let representable2: [any PartsRepresentable] = [str, UIImage()]
+      _ = ModelContent(parts: representable2)
+      _ = ModelContent(parts: [str, UIImage(),
+                               ModelContent.Part.text(str)] as [any PartsRepresentable])
+    #elseif canImport(AppKit)
       _ = ModelContent(role: "user", parts: NSImage())
       _ = ModelContent(role: "user", parts: [NSImage()])
       // Note: without `as [any PartsRepresentable]` this will fail to compile with "Cannot convert
@@ -104,18 +116,6 @@ final class GoogleGenerativeAITests: XCTestCase {
       _ =
         ModelContent(parts: [str, NSImage(),
                              ModelContent.Part.text(str)] as [any PartsRepresentable])
-    #elseif canImport(UIKit)
-      _ = ModelContent(role: "user", parts: UIImage())
-      _ = ModelContent(role: "user", parts: [UIImage()])
-      // Note: without `as [any PartsRepresentable]` this will fail to compile with "Cannot convert
-      // value of type `[Any]` to expected type `[any PartsRepresentable]`. Not sure if there's a
-      // way we can get it to work.
-      _ = ModelContent(parts: [str, UIImage()] as [any PartsRepresentable])
-      // Alternatively, you can explicitly declare the type in a variable and pass it in.
-      let representable2: [any PartsRepresentable] = [str, UIImage()]
-      _ = ModelContent(parts: representable2)
-      _ = ModelContent(parts: [str, UIImage(),
-                               ModelContent.Part.text(str)] as [any PartsRepresentable])
     #endif
 
     // countTokens API

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -175,7 +175,7 @@ case "$platform" in
 
   catalyst)
     xcb_flags=("${catalyst_flags[@]}")
-    destination='platform="macOS,variant=Mac Catalyst,arch=x86_64" TARGETED_DEVICE_FAMILY=2'
+    destination='platform="macOS,variant=Mac Catalyst,name=Any Mac'
     ;;
 
   all)


### PR DESCRIPTION
- Mac Catalyst apps can import both `UIKit` and `AppKit` but `NSImage` (from `AppKit`) is unavailable in Catalyst
  - Re-ordered `#if canImport(UIKit)` before `#elseif canImport(AppKit)` so that the `UIKit` branch is picked in Catalyst builds (`UIImage` is available in Catalyst)
- This builds and tests pass when targeting "`My Mac (Mac Catalyst)`".