### PR TITLE
Warning instead of error for un-fully supported platforms

### DIFF
--- a/Sources/GoogleAI/GenerativeAISwift.swift
+++ b/Sources/GoogleAI/GenerativeAISwift.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 #if !os(macOS) && !os(iOS)
-  #error("Only iOS and macOS targets are currently supported.")
+  #warning("Only iOS, macOS, and Catalyst targets are currently fully supported.")
 #endif
 
 /// Constants associated with the GenerativeAISwift SDK


### PR DESCRIPTION
## Description of the change
Give a warning instead of error for unsupported platforms, since some or most functionality should work on other platforms.