### PR TITLE
Check for empty API_KEY in plist

### DIFF
--- a/Examples/GenerativeAISample/APIKey/APIKey.swift
+++ b/Examples/GenerativeAISample/APIKey/APIKey.swift
@@ -26,7 +26,7 @@ enum APIKey {
     guard let value = plist?.object(forKey: "API_KEY") as? String else {
       fatalError("Couldn't find key 'API_KEY' in 'GenerativeAI-Info.plist'.")
     }
-    if value.starts(with: "_") {
+    if value.starts(with: "_") || value.isEmpty {
       fatalError(
         "Follow the instructions at https://ai.google.dev/tutorials/setup to get an API key."
       )


### PR DESCRIPTION
## Description of the change
Added a check for no api key value being present against the `API_KEY` entry in the plist.

## Motivation
I ran into an issue where I was integrating the SDK within my own application. I copied the `APIKey.swift` enum  file to my project & created the `GenerativeAI-Info.plist` file with an `API_KEY` key-value pair but forgot to copy my own api key against it in the plist. The app ran without producing any results for obvious reasons. I figured other users who merely run the Sample app may also run into the same issue wherein they forget to copy their own api key after creating it.

## Type of change
Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
