### PR TITLE
Add `unsupportedUserLocation` case to `GenerateContentError`

### DIFF
--- a/Sources/GoogleAI/Errors.swift
+++ b/Sources/GoogleAI/Errors.swift
@@ -34,6 +34,10 @@ struct RPCError: Error {
   func isInvalidAPIKeyError() -> Bool {
     return errorInfo?.reason == "API_KEY_INVALID"
   }
+
+  func isUnsupportedUserLocationError() -> Bool {
+    return message == RPCErrorMessage.unsupportedUserLocation.rawValue
+  }
 }
 
 extension RPCError: Decodable {
@@ -173,6 +177,10 @@ enum RPCStatus: String, Decodable {
 
   // Unrecoverable data loss or corruption.
   case dataLoss = "DATA_LOSS"
+}
+
+enum RPCErrorMessage: String {
+  case unsupportedUserLocation = "User location is not supported for the API use."
 }
 
 enum InvalidCandidateError: Error {

--- a/Sources/GoogleAI/GenerateContentError.swift
+++ b/Sources/GoogleAI/GenerateContentError.swift
@@ -27,4 +27,14 @@ public enum GenerateContentError: Error {
 
   /// The provided API key is invalid.
   case invalidAPIKey
+
+  /// The user's location (region) is not supported by the API.
+  ///
+  /// See the Google documentation for a
+  /// [list of regions](https://ai.google.dev/available_regions#available_regions)
+  /// (countries and territories) where the API is available.
+  ///
+  /// - Important: The API is only available in
+  /// [specific regions](https://ai.google.dev/available_regions#available_regions).
+  case unsupportedUserLocation
 }

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -246,6 +246,8 @@ public final class GenerativeModel {
       return error
     } else if let error = error as? RPCError, error.isInvalidAPIKeyError() {
       return GenerateContentError.invalidAPIKey
+    } else if let error = error as? RPCError, error.isUnsupportedUserLocationError() {
+      return GenerateContentError.unsupportedUserLocation
     }
     return GenerateContentError.internalError(underlying: error)
   }

--- a/Tests/GoogleAITests/GenerateContentResponses/unary-failure-unsupported-user-location.json
+++ b/Tests/GoogleAITests/GenerateContentResponses/unary-failure-unsupported-user-location.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": 400,
+    "message": "User location is not supported for the API use.",
+    "status": "FAILED_PRECONDITION",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::failed_precondition: User location is not supported for the API use. [google.rpc.error_details_ext] { message: \"User location is not supported for the API use.\" }"
+      }
+    ]
+  }
+}

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -342,6 +342,24 @@ final class GenerativeModelTests: XCTestCase {
     }
   }
 
+  func testGenerateContent_failure_unsupportedUserLocation() async throws {
+    MockURLProtocol
+      .requestHandler = try httpRequestHandler(
+        forResource: "unary-failure-unsupported-user-location",
+        withExtension: "json",
+        statusCode: 400
+      )
+
+    do {
+      _ = try await model.generateContent(testPrompt)
+      XCTFail("Should throw GenerateContentError.unsupportedUserLocation; no error thrown.")
+    } catch GenerateContentError.unsupportedUserLocation {
+      return
+    }
+
+    XCTFail("Expected an unsupported user location error.")
+  }
+
   func testGenerateContent_failure_nonHTTPResponse() async throws {
     MockURLProtocol.requestHandler = try nonHTTPRequestHandler()
 
@@ -706,6 +724,26 @@ final class GenerativeModelTests: XCTestCase {
     }
 
     XCTFail("Expected an internal decoding error.")
+  }
+
+  func testGenerateContentStream_failure_unsupportedUserLocation() async throws {
+    MockURLProtocol
+      .requestHandler = try httpRequestHandler(
+        forResource: "unary-failure-unsupported-user-location",
+        withExtension: "json",
+        statusCode: 400
+      )
+
+    let stream = model.generateContentStream(testPrompt)
+    do {
+      for try await content in stream {
+        XCTFail("Unexpected content in stream: \(content)")
+      }
+    } catch GenerateContentError.unsupportedUserLocation {
+      return
+    }
+
+    XCTFail("Expected an unsupported user location error.")
   }
 
   // MARK: - Count Tokens


### PR DESCRIPTION
Added a specific `GenerateContentError` case `unsupportedUserLocation` that is thrown when the API is called from a location not in the list of [available regions](https://ai.google.dev/available_regions#available_regions). Previously, this was thrown as an `internalError`, requiring developers to look at the underlying error to determine the failure reason (#82).