### PR TITLE
[Release] Increment `version` to `0.4.6`

### DIFF
--- a/Sources/GoogleAI/GenerativeAISwift.swift
+++ b/Sources/GoogleAI/GenerativeAISwift.swift
@@ -20,6 +20,6 @@ import Foundation
 /// Constants associated with the GenerativeAISwift SDK
 public enum GenerativeAISwift {
   /// String value of the SDK version
-  public static let version = "0.4.4"
+  public static let version = "0.4.6"
   static let baseURL = "https://generativelanguage.googleapis.com/v1"
 }


### PR DESCRIPTION
Note: Skipping from `0.4.4` to `0.4.6` because I missed `0.4.5` before the [release](https://github.com/google/generative-ai-swift/releases/tag/0.4.5) earlier today.