### PR TITLE
Add `invalidAPIKey` case to `GenerateContentError`

### DIFF
--- a/Sources/GoogleAI/GenerateContentError.swift
+++ b/Sources/GoogleAI/GenerateContentError.swift
@@ -24,4 +24,7 @@ public enum GenerateContentError: Error {
 
   /// A response didn't fully complete. See the `FinishReason` for more information.
   case responseStoppedEarly(reason: FinishReason, response: GenerateContentResponse)
+
+  /// The provided API key is invalid.
+  case invalidAPIKey(underlying: Error)
 }

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -108,6 +108,9 @@ public final class GenerativeModel {
     do {
       response = try await generativeAIService.loadRequest(request: generateContentRequest)
     } catch {
+      if let error = error as? RPCError, error.isInvalidAPIKeyError() {
+        throw GenerateContentError.invalidAPIKey(underlying: error)
+      }
       throw GenerateContentError.internalError(underlying: error)
     }
 

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -181,12 +181,12 @@ final class GenerativeModelTests: XCTestCase {
     do {
       _ = try await model.generateContent(testPrompt)
       XCTFail("Should throw GenerateContentError.internalError; no error thrown.")
-    } catch let GenerateContentError.internalError(underlying: rpcError as RPCError) {
-      XCTAssertEqual(rpcError.status, .invalidArgument)
-      XCTAssertEqual(rpcError.httpResponseCode, expectedStatusCode)
-      XCTAssertTrue(rpcError.message.hasPrefix("API key not valid"))
+    } catch let GenerateContentError.invalidAPIKey(underlying: error as RPCError) {
+      XCTAssertEqual(error.status, .invalidArgument)
+      XCTAssertEqual(error.httpResponseCode, expectedStatusCode)
+      XCTAssertTrue(error.message.hasPrefix("API key not valid"))
     } catch {
-      XCTFail("Should throw GenerateContentError.internalError; error thrown: \(error)")
+      XCTFail("Should throw GenerateContentError.invalidAPIKey; error thrown: \(error)")
     }
   }
 


### PR DESCRIPTION
Added an `invalidAPIKey` case to `GenerateContentError` to allow developers to catch invalid API key errors at runtime (e.g., when a key is revoked).

Example usage:
```
do {
  let content = try await model.generateContent("Why is the sky blue?")
} catch GenerateContentError.invalidAPIKey {
  print("The provided API key is invalid.")
}
```