### PR TITLE
Remove `underlyingError` from `GenerateContentError.invalidAPIKey`

### DIFF
--- a/Sources/GoogleAI/GenerateContentError.swift
+++ b/Sources/GoogleAI/GenerateContentError.swift
@@ -26,5 +26,5 @@ public enum GenerateContentError: Error {
   case responseStoppedEarly(reason: FinishReason, response: GenerateContentResponse)
 
   /// The provided API key is invalid.
-  case invalidAPIKey(underlying: Error)
+  case invalidAPIKey
 }

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -181,10 +181,8 @@ final class GenerativeModelTests: XCTestCase {
     do {
       _ = try await model.generateContent(testPrompt)
       XCTFail("Should throw GenerateContentError.internalError; no error thrown.")
-    } catch let GenerateContentError.invalidAPIKey(underlying: error as RPCError) {
-      XCTAssertEqual(error.status, .invalidArgument)
-      XCTAssertEqual(error.httpResponseCode, expectedStatusCode)
-      XCTAssertTrue(error.message.hasPrefix("API key not valid"))
+    } catch GenerateContentError.invalidAPIKey {
+      // Do nothing, catching a GenerateContentError.invalidAPIKey error is expected.
     } catch {
       XCTFail("Should throw GenerateContentError.invalidAPIKey; error thrown: \(error)")
     }


### PR DESCRIPTION
Removed the `underlyingError: Error` associated value from the `GenerateContentError.invalidAPIKey` enum case. We could consider adding a specific value (similar to `RPCError` but public) in the future but for now the enum case itself (`invalidAPIKey`) captures the information that devs need to act on.

Same expected usage as before:
```
do {
  let content = try await model.generateContent("Why is the sky blue?")
} catch GenerateContentError.invalidAPIKey {
  // Devs can decide how they want to display this error to users
  print("The provided API key is invalid.")
} catch {
  // A different error occurred
}
```