### PR TITLE
Throw `GenerateContentError.invalidAPIKey` in `generateContentStream`

### DIFF
--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -439,6 +439,26 @@ final class GenerativeModelTests: XCTestCase {
 
   // MARK: - Generate Content (Streaming)
 
+  func testGenerateContentStream_failureInvalidAPIKey() async throws {
+    MockURLProtocol
+      .requestHandler = try httpRequestHandler(
+        forResource: "unary-failure-api-key",
+        withExtension: "json"
+      )
+
+    do {
+      let stream = model.generateContentStream("Hi")
+      for try await _ in stream {
+        XCTFail("No content is there, this shouldn't happen.")
+      }
+    } catch GenerateContentError.invalidAPIKey {
+      // invalidAPIKey error is as expected, nothing else to check.
+      return
+    }
+
+    XCTFail("Should have caught an error.")
+  }
+
   func testGenerateContentStream_failureEmptyContent() async throws {
     MockURLProtocol
       .requestHandler = try httpRequestHandler(


### PR DESCRIPTION
- Fixed `generateContentStream` to throw `GenerateContentError.invalidAPIKey` instead of `GenerateContentError.internalError`
  - Now matches the `generateContent` behaviour (changed in #91 / #92)
- Added a unit test for this scenario
  - Note: Uses the same `unary-failure-api-key.json` sample response as the `generateContent` test since the backend response is the same for both unary and streaming requests