### PR TITLE
Update `ErrorDetailsView` in the Chat Sample to handle `invalidAPIKey`

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
@@ -142,6 +142,22 @@ struct ErrorDetailsView: View {
             SafetyRatingsSection(ratings: ratings)
           }
 
+        case GenerateContentError.invalidAPIKey:
+          Section("Error Type") {
+            Text("Invalid API Key")
+          }
+
+          Section("Details") {
+            SubtitleFormRow(title: "Error description", value: error.localizedDescription)
+            SubtitleMarkdownFormRow(
+              title: "Help",
+              value: """
+              The provided API key is invalid.
+              Please update `API_KEY` in the `GenerativeAI-Info.plist` file.
+              """
+            )
+          }
+
         default:
           Section("Error Type") {
             Text("Some other error")
@@ -158,49 +174,55 @@ struct ErrorDetailsView: View {
   }
 }
 
-#Preview {
-  NavigationView {
-    let _ = GenerateContentError.promptBlocked(
-      response: GenerateContentResponse(candidates: [
-        CandidateResponse(content: ModelContent(role: "model", [
-          """
-            A _hypothetical_ model response.
-            Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
-          """,
-        ]),
-        safetyRatings: [
-          SafetyRating(category: .dangerousContent, probability: .high),
-          SafetyRating(category: .harassment, probability: .low),
-          SafetyRating(category: .hateSpeech, probability: .low),
-          SafetyRating(category: .sexuallyExplicit, probability: .low),
-        ],
-        finishReason: FinishReason.other,
-        citationMetadata: nil),
+#Preview("Response Stopped Early") {
+  let error = GenerateContentError.responseStoppedEarly(
+    reason: .maxTokens,
+    response: GenerateContentResponse(candidates: [
+      CandidateResponse(content: ModelContent(role: "model", [
+        """
+          A _hypothetical_ model response.
+          Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
+        """,
+      ]),
+      safetyRatings: [
+        SafetyRating(category: .dangerousContent, probability: .high),
+        SafetyRating(category: .harassment, probability: .low),
+        SafetyRating(category: .hateSpeech, probability: .low),
+        SafetyRating(category: .sexuallyExplicit, probability: .low),
       ],
-      promptFeedback: nil)
-    )
+      finishReason: FinishReason.maxTokens,
+      citationMetadata: nil),
+    ],
+    promptFeedback: nil)
+  )
 
-    let errorFinishedEarly = GenerateContentError.responseStoppedEarly(
-      reason: .maxTokens,
-      response: GenerateContentResponse(candidates: [
-        CandidateResponse(content: ModelContent(role: "model", [
-          """
-            A _hypothetical_ model response.
-            Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
-          """,
-        ]),
-        safetyRatings: [
-          SafetyRating(category: .dangerousContent, probability: .high),
-          SafetyRating(category: .harassment, probability: .low),
-          SafetyRating(category: .hateSpeech, probability: .low),
-          SafetyRating(category: .sexuallyExplicit, probability: .low),
-        ],
-        finishReason: FinishReason.maxTokens,
-        citationMetadata: nil),
+  return ErrorDetailsView(error: error)
+}
+
+#Preview("Prompt Blocked") {
+  let error = GenerateContentError.promptBlocked(
+    response: GenerateContentResponse(candidates: [
+      CandidateResponse(content: ModelContent(role: "model", [
+        """
+          A _hypothetical_ model response.
+          Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
+        """,
+      ]),
+      safetyRatings: [
+        SafetyRating(category: .dangerousContent, probability: .high),
+        SafetyRating(category: .harassment, probability: .low),
+        SafetyRating(category: .hateSpeech, probability: .low),
+        SafetyRating(category: .sexuallyExplicit, probability: .low),
       ],
-      promptFeedback: nil)
-    )
+      finishReason: FinishReason.other,
+      citationMetadata: nil),
+    ],
+    promptFeedback: nil)
+  )
 
-    ErrorDetailsView(error: errorFinishedEarly)
-  }
+  return ErrorDetailsView(error: error)
+}
+
+#Preview("Invalid API Key") {
+  ErrorDetailsView(error: GenerateContentError.invalidAPIKey)
 }

--- a/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
@@ -180,8 +180,8 @@ struct ErrorDetailsView: View {
     response: GenerateContentResponse(candidates: [
       CandidateResponse(content: ModelContent(role: "model", [
         """
-          A _hypothetical_ model response.
-          Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
+        A _hypothetical_ model response.
+        Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
         """,
       ]),
       safetyRatings: [
@@ -204,8 +204,8 @@ struct ErrorDetailsView: View {
     response: GenerateContentResponse(candidates: [
       CandidateResponse(content: ModelContent(role: "model", [
         """
-          A _hypothetical_ model response.
-          Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
+        A _hypothetical_ model response.
+        Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
         """,
       ]),
       safetyRatings: [

--- a/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
@@ -152,8 +152,7 @@ struct ErrorDetailsView: View {
             SubtitleMarkdownFormRow(
               title: "Help",
               value: """
-              The provided API key is invalid.
-              Please update `API_KEY` in the `GenerativeAI-Info.plist` file.
+              Please provide a valid value for `API_KEY` in the `GenerativeAI-Info.plist` file.
               """
             )
           }


### PR DESCRIPTION
Updated the `ErrorDetailsView` in the Chat Sample to handle the new `GenerateContentError.invalidAPIKey` case and added a Swift Preview for it.

Note: This won't get triggered until #93 is merged.

Preview: 
![Invalid API Key ErrorDetailsView Screenshot](https://github.com/google/generative-ai-swift/assets/3010484/78dcb6a0-bd2d-4a97-af41-14c87834ea97)