### PR TITLE
Update Chat Sample to handle `unsupportedUserLocation` case

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
@@ -167,7 +167,7 @@ struct ErrorDetailsView: View {
             SubtitleMarkdownFormRow(
               title: "Help",
               value: """
-              The API is unsupported in your location (country / territory); please see
+              The API is unsupported in your location (country / territory); please see the list of
               [available regions](https://ai.google.dev/available_regions#available_regions).
               """
             )

--- a/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
+++ b/Examples/GenerativeAISample/ChatSample/Views/ErrorDetailsView.swift
@@ -157,6 +157,22 @@ struct ErrorDetailsView: View {
             )
           }
 
+        case GenerateContentError.unsupportedUserLocation:
+          Section("Error Type") {
+            Text("Unsupported User Location")
+          }
+
+          Section("Details") {
+            SubtitleFormRow(title: "Error description", value: error.localizedDescription)
+            SubtitleMarkdownFormRow(
+              title: "Help",
+              value: """
+              The API is unsupported in your location (country / territory); please see
+              [available regions](https://ai.google.dev/available_regions#available_regions).
+              """
+            )
+          }
+
         default:
           Section("Error Type") {
             Text("Some other error")
@@ -224,4 +240,8 @@ struct ErrorDetailsView: View {
 
 #Preview("Invalid API Key") {
   ErrorDetailsView(error: GenerateContentError.invalidAPIKey)
+}
+
+#Preview("Unsupported User Location") {
+  ErrorDetailsView(error: GenerateContentError.unsupportedUserLocation)
 }


### PR DESCRIPTION
Updated the `ErrorDetailsView` in the Chat Sample to handle the new `GenerateContentError.unsupportedUserLocation` case and added a Swift Preview for it.

Preview:
![ErrorDetailsView Unsupported User Location Screenshot](https://github.com/google/generative-ai-swift/assets/3010484/df9c81ad-8667-4a27-96d9-1d6cf546bbc4)
