### PR TITLE
Add support for additional model name prefixes

### DIFF
--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -249,7 +249,7 @@ public final class GenerativeModel {
 
   /// Returns a model resource name of the form "models/model-name" based on `name`.
   private static func modelResourceName(name: String) -> String {
-    if name.hasPrefix(modelResourcePrefix) || name.hasPrefix(tunedModelResourcePrefix) {
+    if name.contains("/") {
       return name
     } else {
       return modelResourcePrefix + name

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -20,8 +20,11 @@ public final class GenerativeModel {
   // The prefix for a model resource in the Gemini API.
   private static let modelResourcePrefix = "models/"
 
+  // The prefix for a tuned model resource in the Gemini API.
+  private static let tunedModelResourcePrefix = "tunedModels/"
+
   /// The resource name of the model in the backend; has the format "models/model-name".
-  private let modelResourceName: String
+  let modelResourceName: String
 
   /// The backing service responsible for sending and receiving model requests to the backend.
   let generativeAIService: GenerativeAIService
@@ -246,7 +249,7 @@ public final class GenerativeModel {
 
   /// Returns a model resource name of the form "models/model-name" based on `name`.
   private static func modelResourceName(name: String) -> String {
-    if name.hasPrefix(modelResourcePrefix) {
+    if name.hasPrefix(modelResourcePrefix) || name.hasPrefix(tunedModelResourcePrefix) {
       return name
     } else {
       return modelResourcePrefix + name

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -845,6 +845,41 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(response.totalTokens, 6)
   }
 
+  // MARK: - Model Resource Name
+
+  func testModelResourceName_noPrefix() async throws {
+    let modelName = "my-model"
+    let modelResourceName = "models/\(modelName)"
+
+    model = GenerativeModel(name: modelName, apiKey: "API_KEY")
+
+    XCTAssertEqual(model.modelResourceName, modelResourceName)
+  }
+
+  func testModelResourceName_modelsPrefix() async throws {
+    let modelResourceName = "models/my-model"
+
+    model = GenerativeModel(name: modelResourceName, apiKey: "API_KEY")
+
+    XCTAssertEqual(model.modelResourceName, modelResourceName)
+  }
+
+  func testModelResourceName_tunedModelsPrefix() async throws {
+    let tunedModelResourceName = "tunedModels/my-model"
+
+    model = GenerativeModel(name: tunedModelResourceName, apiKey: "API_KEY")
+
+    XCTAssertEqual(model.modelResourceName, tunedModelResourceName)
+  }
+
+  func testModelResourceName_invalidPrefix() async throws {
+    let invalidModelName = "invalidPrefix/my-model"
+
+    model = GenerativeModel(name: invalidModelName, apiKey: "API_KEY")
+
+    XCTAssertEqual(model.modelResourceName, "models/\(invalidModelName)")
+  }
+
   // MARK: - Helpers
 
   private func nonHTTPRequestHandler() throws -> ((URLRequest) -> (

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -872,14 +872,6 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(model.modelResourceName, tunedModelResourceName)
   }
 
-  func testModelResourceName_invalidPrefix() async throws {
-    let invalidModelName = "invalidPrefix/my-model"
-
-    model = GenerativeModel(name: invalidModelName, apiKey: "API_KEY")
-
-    XCTAssertEqual(model.modelResourceName, "models/\(invalidModelName)")
-  }
-
   // MARK: - Helpers
 
   private func nonHTTPRequestHandler() throws -> ((URLRequest) -> (


### PR DESCRIPTION
- Future-proofed the SDK to support additional model name prefixes (e.g., `myPrefix/` in addition to `models/`)
  - If no prefix is provided then the default `models/` prefix will be prepended (e.g., `"gemini-pro"` is equivalent to `"models/gemini-pro"`)