### PR TITLE
Add `RequestOptions` to `GenerativeModel` constructor

### DIFF
--- a/Sources/GoogleAI/CountTokensRequest.swift
+++ b/Sources/GoogleAI/CountTokensRequest.swift
@@ -17,6 +17,7 @@ import Foundation
 struct CountTokensRequest {
   let model: String
   let contents: [ModelContent]
+  let options: RequestOptions?
 }
 
 extension CountTokensRequest: Encodable {

--- a/Sources/GoogleAI/GenerateContentRequest.swift
+++ b/Sources/GoogleAI/GenerateContentRequest.swift
@@ -21,6 +21,7 @@ struct GenerateContentRequest {
   let generationConfig: GenerationConfig?
   let safetySettings: [SafetySetting]?
   let isStreaming: Bool
+  let options: RequestOptions?
 }
 
 extension GenerateContentRequest: Encodable {

--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -18,4 +18,21 @@ protocol GenerativeAIRequest: Encodable {
   associatedtype Response: Decodable
 
   var url: URL { get }
+
+  var options: RequestOptions? { get }
+}
+
+/// Configuration parameters for sending requests to the backend.
+public struct RequestOptions {
+  /// The request’s timeout interval in seconds; if not specified uses the default value for a
+  /// `URLRequest`.
+  let timeout: TimeInterval?
+
+  /// Initializes a request options object.
+  ///
+  /// - Parameter timeout The request’s timeout interval in seconds; if not specified uses the
+  /// default value for a `URLRequest`.
+  public init(timeout: TimeInterval? = nil) {
+    self.timeout = timeout
+  }
 }

--- a/Sources/GoogleAI/GenerativeAIService.swift
+++ b/Sources/GoogleAI/GenerativeAIService.swift
@@ -156,6 +156,10 @@ struct GenerativeAIService {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     urlRequest.httpBody = try encoder.encode(request)
 
+    if let timeoutInterval = request.options?.timeout {
+      urlRequest.timeoutInterval = timeoutInterval
+    }
+
     return urlRequest
   }
 


### PR DESCRIPTION
Allows developers to specify configuration options for requests sent to the backend (e.g., the request's timeout).