### PR TITLE
Make `requestOptions` non-optional in `GenerativeModel`

### DIFF
--- a/Sources/GoogleAI/CountTokensRequest.swift
+++ b/Sources/GoogleAI/CountTokensRequest.swift
@@ -17,7 +17,7 @@ import Foundation
 struct CountTokensRequest {
   let model: String
   let contents: [ModelContent]
-  let options: RequestOptions?
+  let options: RequestOptions
 }
 
 extension CountTokensRequest: Encodable {

--- a/Sources/GoogleAI/GenerateContentRequest.swift
+++ b/Sources/GoogleAI/GenerateContentRequest.swift
@@ -21,7 +21,7 @@ struct GenerateContentRequest {
   let generationConfig: GenerationConfig?
   let safetySettings: [SafetySetting]?
   let isStreaming: Bool
-  let options: RequestOptions?
+  let options: RequestOptions
 }
 
 extension GenerateContentRequest: Encodable {

--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -19,7 +19,7 @@ protocol GenerativeAIRequest: Encodable {
 
   var url: URL { get }
 
-  var options: RequestOptions? { get }
+  var options: RequestOptions { get }
 }
 
 /// Configuration parameters for sending requests to the backend.

--- a/Sources/GoogleAI/GenerativeAIService.swift
+++ b/Sources/GoogleAI/GenerativeAIService.swift
@@ -156,7 +156,7 @@ struct GenerativeAIService {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     urlRequest.httpBody = try encoder.encode(request)
 
-    if let timeoutInterval = request.options?.timeout {
+    if let timeoutInterval = request.options.timeout {
       urlRequest.timeoutInterval = timeoutInterval
     }
 

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -33,22 +33,21 @@ public final class GenerativeModel {
   let safetySettings: [SafetySetting]?
 
   /// Configuration parameters for sending requests to the backend.
-  let requestOptions: RequestOptions?
+  let requestOptions: RequestOptions
 
   /// Initializes a new remote model with the given parameters.
   ///
-  /// - Parameter name: The name of the model to be used, e.g., "gemini-pro" or "models/gemini-pro".
-  /// - Parameter apiKey: The API key for your project.
-  /// - Parameter generationConfig: A value containing the content generation parameters your model
-  ///     should use.
-  /// - Parameter safetySettings: A value describing what types of harmful content your model
-  ///     should allow.
-  /// - Parameter requestOptions Configuration parameters for sending requests to the backend.
+  /// - Parameters:
+  ///   - name: The name of the model to be used, e.g., "gemini-pro" or "models/gemini-pro".
+  ///   - apiKey: The API key for your project.
+  ///   - generationConfig: The content generation parameters your model should use.
+  ///   - safetySettings: A value describing what types of harmful content your model should allow.
+  ///   - requestOptions Configuration parameters for sending requests to the backend.
   public convenience init(name: String,
                           apiKey: String,
                           generationConfig: GenerationConfig? = nil,
                           safetySettings: [SafetySetting]? = nil,
-                          requestOptions: RequestOptions? = nil) {
+                          requestOptions: RequestOptions = RequestOptions()) {
     self.init(
       name: name,
       apiKey: apiKey,
@@ -64,7 +63,7 @@ public final class GenerativeModel {
        apiKey: String,
        generationConfig: GenerationConfig? = nil,
        safetySettings: [SafetySetting]? = nil,
-       requestOptions: RequestOptions? = nil,
+       requestOptions: RequestOptions = RequestOptions(),
        urlSession: URLSession) {
     modelResourceName = GenerativeModel.modelResourceName(name: name)
     generativeAIService = GenerativeAIService(apiKey: apiKey, urlSession: urlSession)


### PR DESCRIPTION
Use `RequestOptions()` as the default value instead of `nil` in the `GenerativeModel` constructor.