### PR TITLE
Add `apiVersion` to `RequestOptions`

### DIFF
--- a/Sources/GoogleAI/CountTokensRequest.swift
+++ b/Sources/GoogleAI/CountTokensRequest.swift
@@ -33,7 +33,7 @@ extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
   var url: URL {
-    URL(string: "\(GenerativeAISwift.baseURL)/\(model):countTokens")!
+    URL(string: "\(GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model):countTokens")!
   }
 }
 

--- a/Sources/GoogleAI/GenerateContentRequest.swift
+++ b/Sources/GoogleAI/GenerateContentRequest.swift
@@ -39,10 +39,11 @@ extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 
   var url: URL {
+    let modelURL = "\(GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model)"
     if isStreaming {
-      return URL(string: "\(GenerativeAISwift.baseURL)/\(model):streamGenerateContent?alt=sse")!
+      return URL(string: "\(modelURL):streamGenerateContent?alt=sse")!
     } else {
-      return URL(string: "\(GenerativeAISwift.baseURL)/\(model):generateContent")!
+      return URL(string: "\(modelURL):generateContent")!
     }
   }
 }

--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -30,11 +30,17 @@ public struct RequestOptions {
   /// `URLRequest`.
   let timeout: TimeInterval?
 
+  /// The API version to use in requests to the backend.
+  let apiVersion: String
+
   /// Initializes a request options object.
   ///
-  /// - Parameter timeout The request’s timeout interval in seconds; if not specified uses the
-  /// default value for a `URLRequest`.
-  public init(timeout: TimeInterval? = nil) {
+  /// - Parameters:
+  ///   - timeout The request’s timeout interval in seconds; if not specified uses the default value
+  ///   for a `URLRequest`.
+  ///   - apiVersion The API version to use in requests to the backend; defaults to "v1".
+  public init(timeout: TimeInterval? = nil, apiVersion: String = "v1") {
     self.timeout = timeout
+    self.apiVersion = apiVersion
   }
 }

--- a/Sources/GoogleAI/GenerativeAISwift.swift
+++ b/Sources/GoogleAI/GenerativeAISwift.swift
@@ -22,5 +22,5 @@ import Foundation
 public enum GenerativeAISwift {
   /// String value of the SDK version
   public static let version = "0.4.7"
-  static let baseURL = "https://generativelanguage.googleapis.com/v1"
+  static let baseURL = "https://generativelanguage.googleapis.com"
 }


### PR DESCRIPTION
Added `apiVersion` to `RequestOptions`, which allows developers to optionally target a specific version of the API (for example, `"v1beta"`); defaults to `"v1"` if not specified.