### PR TITLE
Lower minimum required OS versions in Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ import PackageDescription
 let package = Package(
   name: "generative-ai-swift",
   platforms: [
-    .iOS(.v15),
-    .macOS(.v11),
-    .macCatalyst(.v15),
+    .iOS(.v11),
+    .macOS(.v10_13),
+    .macCatalyst(.v13),
   ],
   products: [
     .library(

--- a/Sources/GoogleAI/Chat.swift
+++ b/Sources/GoogleAI/Chat.swift
@@ -16,6 +16,7 @@ import Foundation
 
 /// An object that represents a back-and-forth chat with a model, capturing the history and saving
 /// the context in memory between each message sent.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public class Chat {
   private let model: GenerativeModel
 

--- a/Sources/GoogleAI/CountTokensRequest.swift
+++ b/Sources/GoogleAI/CountTokensRequest.swift
@@ -14,18 +14,21 @@
 
 import Foundation
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 struct CountTokensRequest {
   let model: String
   let contents: [ModelContent]
   let options: RequestOptions
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension CountTokensRequest: Encodable {
   enum CodingKeys: CodingKey {
     case contents
   }
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
@@ -35,6 +38,7 @@ extension CountTokensRequest: GenerativeAIRequest {
 }
 
 /// The model's response to a count tokens request.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct CountTokensResponse: Decodable {
   /// The total number of tokens in the input given to the model as a prompt.
   public let totalTokens: Int

--- a/Sources/GoogleAI/GenerateContentError.swift
+++ b/Sources/GoogleAI/GenerateContentError.swift
@@ -15,6 +15,7 @@
 import Foundation
 
 /// Errors that occur when generating content from a model.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public enum GenerateContentError: Error {
   /// An internal error occurred. See the underlying error for more context.
   case internalError(underlying: Error)

--- a/Sources/GoogleAI/GenerateContentRequest.swift
+++ b/Sources/GoogleAI/GenerateContentRequest.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 struct GenerateContentRequest {
   /// Model name.
   let model: String
@@ -24,6 +25,7 @@ struct GenerateContentRequest {
   let options: RequestOptions
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension GenerateContentRequest: Encodable {
   enum CodingKeys: String, CodingKey {
     case contents
@@ -32,6 +34,7 @@ extension GenerateContentRequest: Encodable {
   }
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 

--- a/Sources/GoogleAI/GenerateContentResponse.swift
+++ b/Sources/GoogleAI/GenerateContentResponse.swift
@@ -15,6 +15,7 @@
 import Foundation
 
 /// The model's response to a generate content request.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct GenerateContentResponse {
   /// A list of candidate response content, ordered from best to worst.
   public let candidates: [CandidateResponse]
@@ -43,6 +44,7 @@ public struct GenerateContentResponse {
   }
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension GenerateContentResponse: Decodable {
   enum CodingKeys: CodingKey {
     case candidates
@@ -76,6 +78,7 @@ extension GenerateContentResponse: Decodable {
 
 /// A struct representing a possible reply to a content generation prompt. Each content generation
 /// prompt may produce multiple candidate responses.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct CandidateResponse {
   /// The response's content.
   public let content: ModelContent
@@ -100,6 +103,7 @@ public struct CandidateResponse {
   }
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension CandidateResponse: Decodable {
   enum CodingKeys: CodingKey {
     case content
@@ -149,12 +153,14 @@ extension CandidateResponse: Decodable {
 }
 
 /// A collection of source attributions for a piece of content.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct CitationMetadata: Decodable {
   /// A list of individual cited sources and the parts of the content to which they apply.
   public let citationSources: [Citation]
 }
 
 /// A struct describing a source attribution.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct Citation: Decodable {
   /// The inclusive beginning of a sequence in a model response that derives from a cited source.
   public let startIndex: Int
@@ -170,6 +176,7 @@ public struct Citation: Decodable {
 }
 
 /// A value enumerating possible reasons for a model to terminate a content generation request.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public enum FinishReason: String {
   case unknown = "FINISH_REASON_UNKNOWN"
 
@@ -193,6 +200,7 @@ public enum FinishReason: String {
   case other = "OTHER"
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension FinishReason: Decodable {
   /// Do not explicitly use. Initializer required for Decodable conformance.
   public init(from decoder: Decoder) throws {
@@ -209,6 +217,7 @@ extension FinishReason: Decodable {
 }
 
 /// A metadata struct containing any feedback the model had on the prompt it was provided.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct PromptFeedback {
   /// A type describing possible reasons to block a prompt.
   public enum BlockReason: String, Decodable {
@@ -251,6 +260,7 @@ public struct PromptFeedback {
   }
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension PromptFeedback: Decodable {
   enum CodingKeys: CodingKey {
     case blockReason

--- a/Sources/GoogleAI/GenerationConfig.swift
+++ b/Sources/GoogleAI/GenerationConfig.swift
@@ -16,6 +16,7 @@ import Foundation
 
 /// A struct defining model parameters to be used when sending generative AI
 /// requests to the backend model.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct GenerationConfig: Encodable {
   /// A parameter controlling the degree of randomness in token selection. A
   /// temperature of zero is deterministic, always choosing the

--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 protocol GenerativeAIRequest: Encodable {
   associatedtype Response: Decodable
 
@@ -23,6 +24,7 @@ protocol GenerativeAIRequest: Encodable {
 }
 
 /// Configuration parameters for sending requests to the backend.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct RequestOptions {
   /// The request’s timeout interval in seconds; if not specified uses the default value for a
   /// `URLRequest`.

--- a/Sources/GoogleAI/GenerativeAIService.swift
+++ b/Sources/GoogleAI/GenerativeAIService.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 struct GenerativeAIService {
   /// Gives permission to talk to the backend.
   private let apiKey: String

--- a/Sources/GoogleAI/GenerativeAISwift.swift
+++ b/Sources/GoogleAI/GenerativeAISwift.swift
@@ -18,6 +18,7 @@ import Foundation
 #endif
 
 /// Constants associated with the GenerativeAISwift SDK
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public enum GenerativeAISwift {
   /// String value of the SDK version
   public static let version = "0.4.7"

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -16,6 +16,7 @@ import Foundation
 
 /// A type that represents a remote multimodal model (like Gemini), with the ability to generate
 /// content based on various input types.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public final class GenerativeModel {
   // The prefix for a model resource in the Gemini API.
   private static let modelResourcePrefix = "models/"
@@ -268,6 +269,7 @@ public final class GenerativeModel {
 }
 
 /// See ``GenerativeModel/countTokens(_:)-9spwl``.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public enum CountTokensError: Error {
   case internalError(underlying: Error)
 }

--- a/Sources/GoogleAI/Logging.swift
+++ b/Sources/GoogleAI/Logging.swift
@@ -15,6 +15,7 @@
 import Foundation
 import OSLog
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 struct Logging {
   /// Subsystem that should be used for all Loggers.
   static let subsystem = "com.google.generative-ai"

--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -17,6 +17,7 @@ import Foundation
 /// A type describing data in media formats interpretable by an AI model. Each generative AI
 /// request or response contains an `Array` of ``ModelContent``s, and each ``ModelContent`` value
 /// may comprise multiple heterogeneous ``ModelContent/Part``s.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct ModelContent: Codable, Equatable {
   /// A discrete piece of data in a media format intepretable by an AI model. Within a single value
   /// of ``Part``, different data types may not mix.

--- a/Sources/GoogleAI/PartsRepresentable.swift
+++ b/Sources/GoogleAI/PartsRepresentable.swift
@@ -23,11 +23,13 @@ import UniformTypeIdentifiers
 private let imageCompressionQuality: CGFloat = 0.8
 
 /// A protocol describing any data that could be interpreted as model input data.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public protocol PartsRepresentable {
   var partsValue: [ModelContent.Part] { get }
 }
 
 /// Enables a `String` to be passed in as ``PartsRepresentable``.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension String: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     return [.text(self)]
@@ -35,6 +37,7 @@ extension String: PartsRepresentable {
 }
 
 /// Enables a ``ModelContent.Part`` to be passed in as ``PartsRepresentable``.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension ModelContent.Part: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     return [self]
@@ -43,6 +46,7 @@ extension ModelContent.Part: PartsRepresentable {
 
 /// Enable an `Array` of ``PartsRepresentable`` values to be passed in as a single
 /// ``PartsRepresentable``.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension [any PartsRepresentable]: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     return flatMap { $0.partsValue }
@@ -51,6 +55,7 @@ extension [any PartsRepresentable]: PartsRepresentable {
 
 #if canImport(UIKit)
   /// Enables images to be representable as ``PartsRepresentable``.
+  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
   extension UIImage: PartsRepresentable {
     public var partsValue: [ModelContent.Part] {
       guard let data = jpegData(compressionQuality: imageCompressionQuality) else {
@@ -64,6 +69,7 @@ extension [any PartsRepresentable]: PartsRepresentable {
 
 #elseif canImport(AppKit)
   /// Enables images to be representable as ``PartsRepresentable``.
+  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
   extension NSImage: PartsRepresentable {
     public var partsValue: [ModelContent.Part] {
       guard let cgImage = cgImage(forProposedRect: nil, context: nil, hints: nil) else {
@@ -81,6 +87,7 @@ extension [any PartsRepresentable]: PartsRepresentable {
   }
 #endif
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension CGImage: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     let output = NSMutableData()
@@ -102,6 +109,7 @@ extension CGImage: PartsRepresentable {
   }
 }
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 extension CIImage: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     let context = CIContext()

--- a/Sources/GoogleAI/Safety.swift
+++ b/Sources/GoogleAI/Safety.swift
@@ -17,6 +17,7 @@ import Foundation
 /// A type defining potentially harmful media categories and their model-assigned ratings. A value
 /// of this type may be assigned to a category for every model-generated response, not just
 /// responses that exceed a certain threshold.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct SafetyRating: Decodable, Equatable, Hashable {
   /// The category describing the potential harm a piece of content may pose. See
   /// ``SafetySetting/HarmCategory`` for a list of possible values.
@@ -74,6 +75,7 @@ public struct SafetyRating: Decodable, Equatable, Hashable {
 }
 
 /// Safety feedback for an entire request.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct SafetyFeedback: Decodable {
   /// Safety rating evaluated from content.
   public let rating: SafetyRating
@@ -90,6 +92,7 @@ public struct SafetyFeedback: Decodable {
 
 /// A type used to specify a threshold for harmful content, beyond which the model will return a
 /// fallback response instead of generated content.
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct SafetySetting: Codable {
   /// A type describing safety attributes, which include harmful categories and topics that can
   /// be considered sensitive.

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -20,6 +20,7 @@ import XCTest
   import UIKit // For UIImage extensions.
 #endif
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 final class GoogleGenerativeAITests: XCTestCase {
   func codeSamples() async throws {
     let config = GenerationConfig(temperature: 0.2,

--- a/Tests/GoogleAITests/PartsRepresentableTests.swift
+++ b/Tests/GoogleAITests/PartsRepresentableTests.swift
@@ -21,6 +21,7 @@ import XCTest
   import AppKit
 #endif
 
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 final class PartsRepresentableTests: XCTestCase {
   func testModelContentFromCGImageIsNotEmpty() throws {
     // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2


### PR DESCRIPTION
- Lowered the minimum supported versions to iOS 11+, macOS 10.13+ and macCatalyst 13+ in the Swift **Package**.

Note: The SDK still requires iOS 15+, macOS 11+ and macCatalyst 15+. This allows apps or other SDKs targeting lower versions to depend on the SDK and using availability guards (e.g., `#available(iOS...`).