### PR TITLE
Decrease `swift-tools-version` to `5.7.1`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.7.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2023 Google LLC


### PR DESCRIPTION
Set `swift-tools-version: 5.7.1` in `Package.swift`. This allows the `generative-ai-swift` package to be used (temporarily/unofficially supported) in Xcode 14.1+.
