### PR TITLE
Make `ErrorDetails` an enum with associated values BadRequest/ErrorInfo

### DIFF
--- a/Sources/GoogleAI/Errors.swift
+++ b/Sources/GoogleAI/Errors.swift
@@ -15,24 +15,109 @@
 import Foundation
 
 struct RPCError: Error {
-  let httpResponseCode: Int
-  let message: String
-  let status: RPCStatus
-  let details: [ErrorDetails]
+  enum ErrorDetails {
+    case badRequest(BadRequest)
+    case errorInfo(ErrorInfo)
+    case unknown(String)
 
-  private var errorInfo: ErrorDetails? {
-    return details.first { $0.isErrorInfo() }
+    struct BadRequest {
+      static let type = "type.googleapis.com/google.rpc.BadRequest"
+
+      struct FieldViolation: Decodable {
+        let field: String?
+        let description: String?
+      }
+
+      let type: String
+      let fieldViolations: [FieldViolation]
+    }
+
+    struct ErrorInfo {
+      static let type = "type.googleapis.com/google.rpc.ErrorInfo"
+
+      let type: String
+      let reason: String?
+      let domain: String?
+    }
   }
 
-  init(httpResponseCode: Int, message: String, status: RPCStatus, details: [ErrorDetails]) {
-    self.httpResponseCode = httpResponseCode
+  enum Status: String, Decodable {
+    // Not an error; returned on success.
+    case ok = "OK"
+
+    // The operation was cancelled, typically by the caller.
+    case cancelled = "CANCELLED"
+
+    // Unknown error.
+    case unknown = "UNKNOWN"
+
+    // The client specified an invalid argument.
+    case invalidArgument = "INVALID_ARGUMENT"
+
+    // The deadline expired before the operation could complete.
+    case deadlineExceeded = "DEADLINE_EXCEEDED"
+
+    // Some requested entity (e.g., file or directory) was not found.
+    case notFound = "NOT_FOUND"
+
+    // The entity that a client attempted to create (e.g., file or directory) already exists.
+    case alreadyExists = "ALREADY_EXISTS"
+
+    // The caller does not have permission to execute the specified operation.
+    case permissionDenied = "PERMISSION_DENIED"
+
+    // The request does not have valid authentication credentials for the operation.
+    case unauthenticated = "UNAUTHENTICATED"
+
+    // Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
+    // is out of space.
+    case resourceExhausted = "RESOURCE_EXHAUSTED"
+
+    // The operation was rejected because the system is not in a state required for the operation's
+    // execution.
+    case failedPrecondition = "FAILED_PRECONDITION"
+
+    // The operation was aborted, typically due to a concurrency issue such as a sequencer check
+    // failure or transaction abort.
+    case aborted = "ABORTED"
+
+    // The operation was attempted past the valid range.
+    case outOfRange = "OUT_OF_RANGE"
+
+    // The operation is not implemented or is not supported/enabled in this service.
+    case unimplemented = "UNIMPLEMENTED"
+
+    // Internal errors.
+    case internalError = "INTERNAL"
+
+    // The service is currently unavailable.
+    case unavailable = "UNAVAILABLE"
+
+    // Unrecoverable data loss or corruption.
+    case dataLoss = "DATA_LOSS"
+  }
+
+  let code: Int
+  let message: String
+  let status: Status
+  let details: [ErrorDetails]
+
+  init(httpResponseCode: Int, message: String, status: Status, details: [ErrorDetails]) {
+    code = httpResponseCode
     self.message = message
     self.status = status
     self.details = details
   }
 
   func isInvalidAPIKeyError() -> Bool {
-    return errorInfo?.reason == "API_KEY_INVALID"
+    return details.contains { errorDetails in
+      switch errorDetails {
+      case let .errorInfo(errorInfo):
+        return errorInfo.reason == "API_KEY_INVALID"
+      default:
+        return false
+      }
+    }
   }
 
   func isUnsupportedUserLocationError() -> Bool {
@@ -40,9 +125,23 @@ struct RPCError: Error {
   }
 }
 
+enum InvalidCandidateError: Error {
+  case emptyContent(underlyingError: Error)
+  case malformedContent(underlyingError: Error)
+}
+
+// MARK: - Decodable Conformance
+
 extension RPCError: Decodable {
   enum CodingKeys: CodingKey {
     case error
+  }
+
+  struct ErrorStatus {
+    let code: Int?
+    let message: String?
+    let status: RPCError.Status?
+    let details: [RPCError.ErrorDetails]
   }
 
   init(from decoder: Decoder) throws {
@@ -50,9 +149,9 @@ extension RPCError: Decodable {
     let status = try container.decode(ErrorStatus.self, forKey: .error)
 
     if let code = status.code {
-      httpResponseCode = code
+      self.code = code
     } else {
-      httpResponseCode = -1
+      code = -1
     }
 
     if let message = status.message {
@@ -71,34 +170,7 @@ extension RPCError: Decodable {
   }
 }
 
-struct ErrorStatus {
-  let code: Int?
-  let message: String?
-  let status: RPCStatus?
-  let details: [ErrorDetails]
-}
-
-struct ErrorDetails {
-  static let errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
-
-  let type: String
-  let reason: String?
-  let domain: String?
-
-  func isErrorInfo() -> Bool {
-    return type == ErrorDetails.errorInfoType
-  }
-}
-
-extension ErrorDetails: Decodable, Equatable {
-  enum CodingKeys: String, CodingKey {
-    case type = "@type"
-    case reason
-    case domain
-  }
-}
-
-extension ErrorStatus: Decodable {
+extension RPCError.ErrorStatus: Decodable {
   enum CodingKeys: CodingKey {
     case code
     case message
@@ -111,79 +183,63 @@ extension ErrorStatus: Decodable {
     code = try container.decodeIfPresent(Int.self, forKey: .code)
     message = try container.decodeIfPresent(String.self, forKey: .message)
     do {
-      status = try container.decodeIfPresent(RPCStatus.self, forKey: .status)
+      status = try container.decodeIfPresent(RPCError.Status.self, forKey: .status)
     } catch {
       status = .unknown
     }
     if container.contains(.details) {
-      details = try container.decode([ErrorDetails].self, forKey: .details)
+      details = try container.decode([RPCError.ErrorDetails].self, forKey: .details)
     } else {
       details = []
     }
   }
 }
 
-enum RPCStatus: String, Decodable {
-  // Not an error; returned on success.
-  case ok = "OK"
+extension RPCError.ErrorDetails: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case type = "@type"
+  }
 
-  // The operation was cancelled, typically by the caller.
-  case cancelled = "CANCELLED"
-
-  // Unknown error.
-  case unknown = "UNKNOWN"
-
-  // The client specified an invalid argument.
-  case invalidArgument = "INVALID_ARGUMENT"
-
-  // The deadline expired before the operation could complete.
-  case deadlineExceeded = "DEADLINE_EXCEEDED"
-
-  // Some requested entity (e.g., file or directory) was not found.
-  case notFound = "NOT_FOUND"
-
-  // The entity that a client attempted to create (e.g., file or directory) already exists.
-  case alreadyExists = "ALREADY_EXISTS"
-
-  // The caller does not have permission to execute the specified operation.
-  case permissionDenied = "PERMISSION_DENIED"
-
-  // The request does not have valid authentication credentials for the operation.
-  case unauthenticated = "UNAUTHENTICATED"
-
-  // Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
-  // is out of space.
-  case resourceExhausted = "RESOURCE_EXHAUSTED"
-
-  // The operation was rejected because the system is not in a state required for the operation's
-  // execution.
-  case failedPrecondition = "FAILED_PRECONDITION"
-
-  // The operation was aborted, typically due to a concurrency issue such as a sequencer check
-  // failure or transaction abort.
-  case aborted = "ABORTED"
-
-  // The operation was attempted past the valid range.
-  case outOfRange = "OUT_OF_RANGE"
-
-  // The operation is not implemented or is not supported/enabled in this service.
-  case unimplemented = "UNIMPLEMENTED"
-
-  // Internal errors.
-  case internalError = "INTERNAL"
-
-  // The service is currently unavailable.
-  case unavailable = "UNAVAILABLE"
-
-  // Unrecoverable data loss or corruption.
-  case dataLoss = "DATA_LOSS"
+  init(from decoder: Decoder) throws {
+    let errorDetailsContainer = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try errorDetailsContainer.decode(String.self, forKey: .type)
+    if type == BadRequest.type {
+      let badRequestContainer = try decoder.singleValueContainer()
+      let badRequest = try badRequestContainer.decode(BadRequest.self)
+      self = RPCError.ErrorDetails.badRequest(badRequest)
+    } else if type == ErrorInfo.type {
+      let errorInfoContainer = try decoder.singleValueContainer()
+      let errorInfo = try errorInfoContainer.decode(ErrorInfo.self)
+      self = RPCError.ErrorDetails.errorInfo(errorInfo)
+    } else {
+      self = RPCError.ErrorDetails.unknown(type)
+    }
+  }
 }
 
-enum RPCErrorMessage: String {
+extension RPCError.ErrorDetails.BadRequest: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case type = "@type"
+    case fieldViolations
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    type = try container.decode(String.self, forKey: .type)
+    fieldViolations = try container.decode([FieldViolation].self, forKey: .fieldViolations)
+  }
+}
+
+extension RPCError.ErrorDetails.ErrorInfo: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case type = "@type"
+    case reason
+    case domain
+  }
+}
+
+// MARK: - Private
+
+private enum RPCErrorMessage: String {
   case unsupportedUserLocation = "User location is not supported for the API use."
-}
-
-enum InvalidCandidateError: Error {
-  case emptyContent(underlyingError: Error)
-  case malformedContent(underlyingError: Error)
 }

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -261,7 +261,7 @@ final class GenerativeModelTests: XCTestCase {
       XCTFail("Should throw GenerateContentError.internalError; no error thrown.")
     } catch let GenerateContentError.internalError(underlying: rpcError as RPCError) {
       XCTAssertEqual(rpcError.status, .invalidArgument)
-      XCTAssertEqual(rpcError.httpResponseCode, expectedStatusCode)
+      XCTAssertEqual(rpcError.code, expectedStatusCode)
       XCTAssertEqual(rpcError.message, "Request contains an invalid argument.")
     } catch {
       XCTFail("Should throw GenerateContentError.internalError; error thrown: \(error)")
@@ -335,7 +335,7 @@ final class GenerativeModelTests: XCTestCase {
       XCTFail("Should throw GenerateContentError.internalError; no error thrown.")
     } catch let GenerateContentError.internalError(underlying: rpcError as RPCError) {
       XCTAssertEqual(rpcError.status, .notFound)
-      XCTAssertEqual(rpcError.httpResponseCode, expectedStatusCode)
+      XCTAssertEqual(rpcError.code, expectedStatusCode)
       XCTAssertTrue(rpcError.message.hasPrefix("models/unknown is not found"))
     } catch {
       XCTFail("Should throw GenerateContentError.internalError; error thrown: \(error)")
@@ -671,7 +671,7 @@ final class GenerativeModelTests: XCTestCase {
         responseCount += 1
       }
     } catch let GenerateContentError.internalError(rpcError as RPCError) {
-      XCTAssertEqual(rpcError.httpResponseCode, 499)
+      XCTAssertEqual(rpcError.code, 499)
       XCTAssertEqual(rpcError.status, .cancelled)
 
       // Check the content count is correct.
@@ -815,7 +815,7 @@ final class GenerativeModelTests: XCTestCase {
       _ = try await model.countTokens("Why is the sky blue?")
       XCTFail("Request should not have succeeded.")
     } catch let CountTokensError.internalError(rpcError as RPCError) {
-      XCTAssertEqual(rpcError.httpResponseCode, 404)
+      XCTAssertEqual(rpcError.code, 404)
       XCTAssertEqual(rpcError.status, .notFound)
       XCTAssert(rpcError.message.hasPrefix("models/test-model-name is not found"))
       return


### PR DESCRIPTION
- Renamed `ErrorInfo` to `ErrorDetails`
- Made `details` in `RPCError` an enum representing [`ErrorDetails`](https://cloud.google.com/apis/design/errors#error_details)
  - `errorInfo` case to represent [`ErrorInfo`](https://github.com/googleapis/googleapis/blob/ab4ba823439f786b2091984fed6408a950aaef9e/google/rpc/error_details.proto#L51)
  - `badRequest` case to represent [`BadRequest`](https://github.com/googleapis/googleapis/blob/ab4ba823439f786b2091984fed6408a950aaef9e/google/rpc/error_details.proto#L170)