### PR TITLE
Add documentation link to the Gemini models list

### DIFF
--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -42,7 +42,7 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to be used, e.g., `"gemini-pro"` or `"models/gemini-pro"`; see
+  ///   - name: The name of the model to be used, e.g., `"models/gemini-pro"`; see
   ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -42,7 +42,7 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to be used, e.g., `"models/gemini-pro"`; see
+  ///   - name: The name of the model to use, e.g., `"gemini-pro"`; see
   ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -42,7 +42,8 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to be used, e.g., "gemini-pro" or "models/gemini-pro".
+  ///   - name: The name of the model to be used, e.g., `"gemini-pro"` or `"models/gemini-pro"`; see
+  ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.
   ///   - safetySettings: A value describing what types of harmful content your model should allow.


### PR DESCRIPTION
Added a link to https://ai.google.dev/models/gemini in the `GenerativeModel` constructor documentation. This page lists supported model names (e.g., `gemini-pro` and `gemini-pro-vision`).

Screenshot:
![GenerativeModel Documentation Screenshot](https://github.com/google/generative-ai-swift/assets/3010484/60e2866c-6678-4c33-adfa-e18cd3a0a476)
