### PR TITLE
Increment SDK version to 0.4.8

### DIFF
--- a/Sources/GoogleAI/GenerativeAISwift.swift
+++ b/Sources/GoogleAI/GenerativeAISwift.swift
@@ -21,6 +21,6 @@ import Foundation
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public enum GenerativeAISwift {
   /// String value of the SDK version
-  public static let version = "0.4.7"
+  public static let version = "0.4.8"
   static let baseURL = "https://generativelanguage.googleapis.com"
 }


### PR DESCRIPTION
Updated `GenerativeAISwift.version` to `0.4.8` in preparation for the next release.
