### PR TITLE
Update model name strings in README, docs and samples

### DIFF
--- a/Examples/GenerativeAICLI/Sources/GenerateContent.swift
+++ b/Examples/GenerativeAICLI/Sources/GenerateContent.swift
@@ -118,9 +118,9 @@ struct GenerateContent: AsyncParsableCommand {
     if let modelName = modelName {
       return modelName
     } else if imageURL != nil {
-      return "gemini-pro-vision"
+      return "gemini-1.0-pro-vision-latest"
     } else {
-      return "gemini-pro"
+      return "gemini-1.0-pro"
     }
   }
 }

--- a/Examples/GenerativeAISample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/Examples/GenerativeAISample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = GenerativeModel(name: "gemini-pro", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.0-pro", apiKey: APIKey.default)
     chat = model.startChat()
   }
 

--- a/Examples/GenerativeAISample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/Examples/GenerativeAISample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = GenerativeModel(name: "gemini-pro-vision", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.0-pro-vision-latest", apiKey: APIKey.default)
   }
 
   func reason() async {

--- a/Examples/GenerativeAISample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/Examples/GenerativeAISample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = GenerativeModel(name: "gemini-pro", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.0-pro", apiKey: APIKey.default)
   }
 
   func summarize(inputText: String) async {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For example, with just a few lines of code, you can access Gemini's multimodal c
 generate text from text-and-image input:
 
 ```swift
-let model = GenerativeModel(name: "gemini-pro-vision", apiKey: "YOUR_API_KEY")
+let model = GenerativeModel(name: "gemini-1.0-pro-vision-latest", apiKey: "YOUR_API_KEY")
 let cookieImage = UIImage(...)
 let prompt = "Do these look store-bought or homemade?"
 

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -42,7 +42,7 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to use, e.g., `"gemini-pro"`; see
+  ///   - name: The name of the model to use, e.g., `"gemini-1.0-pro"`; see
   ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -32,12 +32,12 @@ final class GoogleGenerativeAITests: XCTestCase {
     let filters = [SafetySetting(harmCategory: .dangerousContent, threshold: .blockOnlyHigh)]
 
     // Permutations without optional arguments.
-    let _ = GenerativeModel(name: "gemini-pro@001", apiKey: "API_KEY")
-    let _ = GenerativeModel(name: "gemini-pro@001", apiKey: "API_KEY", safetySettings: filters)
-    let _ = GenerativeModel(name: "gemini-pro@001", apiKey: "API_KEY", generationConfig: config)
+    let _ = GenerativeModel(name: "gemini-1.0-pro", apiKey: "API_KEY")
+    let _ = GenerativeModel(name: "gemini-1.0-pro", apiKey: "API_KEY", safetySettings: filters)
+    let _ = GenerativeModel(name: "gemini-1.0-pro", apiKey: "API_KEY", generationConfig: config)
 
     // All arguments passed.
-    let genAI = GenerativeModel(name: "gemini-pro@001",
+    let genAI = GenerativeModel(name: "gemini-1.0-pro",
                                 apiKey: "API_KEY",
                                 generationConfig: config, // Optional
                                 safetySettings: filters // Optional


### PR DESCRIPTION
Updated model name strings from `gemini-pro` to `gemini-1.0-pro` and from `gemini-pro-vision` to `gemini-1.0-pro-vision-latest`. For a list of model names and details about model versions, generations and variants, see https://ai.google.dev/models/gemini.