### PR TITLE
Update `ModelContent.Part` enum decoding strategy

### DIFF
--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -69,13 +69,13 @@ public struct ModelContent: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
-      if let textVal = try? values.decode(String.self, forKey: .text) {
-        self = .text(textVal)
-      } else if let dataContainer = try? values.nestedContainer(
-        keyedBy: InlineDataKeys.self,
-        forKey: .inlineData
-      ) {
-        // Get the data here.
+      if values.contains(.text) {
+        self = try .text(values.decode(String.self, forKey: .text))
+      } else if values.contains(.inlineData) {
+        let dataContainer = try values.nestedContainer(
+          keyedBy: InlineDataKeys.self,
+          forKey: .inlineData
+        )
         let mimetype = try dataContainer.decode(String.self, forKey: .mimeType)
         let bytes = try dataContainer.decode(Data.self, forKey: .bytes)
         self = .data(mimetype: mimetype, bytes)


### PR DESCRIPTION
Updated the `ModelContent.Part` decoding implementation to throw if `text` or `inlineData` fields are included in the payload but decoding fails. This allows us to see the `DecodingError` thrown instead of it being hidden by `try?`.

This makes it consistent with the discussion in https://github.com/google/generative-ai-swift/pull/114#discussion_r1513373712.
