### PR TITLE
Remove unused `tunedModelResourcePrefix` constant

### DIFF
--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -21,9 +21,6 @@ public final class GenerativeModel {
   // The prefix for a model resource in the Gemini API.
   private static let modelResourcePrefix = "models/"
 
-  // The prefix for a tuned model resource in the Gemini API.
-  private static let tunedModelResourcePrefix = "tunedModels/"
-
   /// The resource name of the model in the backend; has the format "models/model-name".
   let modelResourceName: String
 


### PR DESCRIPTION
Removed an unused `tunedModelResourcePrefix` constant from `GenerativeModel`. This was unintentionally left in after the implementation change in [`41a395f` (#98)](https://github.com/google/generative-ai-swift/pull/98/commits/41a395f341bfd040702695a6217c1069c5b05a18).