### PR TITLE
Make `ToolConfig` and `FunctionCallingConfig` optional

### DIFF
--- a/Examples/GenerativeAICLI/Sources/GenerateContent.swift
+++ b/Examples/GenerativeAICLI/Sources/GenerateContent.swift
@@ -98,7 +98,10 @@ struct GenerateContent: AsyncParsableCommand {
             requiredParameters: ["currency_from", "currency_to"]
           ),
         ])],
-        toolConfig: ToolConfig(mode: .any),
+        toolConfig: .init(functionCallingConfig: .init(
+          mode: .any,
+          allowedFunctionNames: ["get_exchange_rate"]
+        )),
         requestOptions: RequestOptions(apiVersion: "v1beta")
       )
 

--- a/Sources/GoogleAI/FunctionCalling.swift
+++ b/Sources/GoogleAI/FunctionCalling.swift
@@ -191,16 +191,23 @@ public enum Mode: String, Encodable {
 }
 
 public struct FunctionCallingConfig: Encodable {
-  let mode: Mode
+  let mode: Mode?
+
+  let allowedFunctionNames: [String]?
+
+  public init(mode: Mode? = nil, allowedFunctionNames: [String]? = nil) {
+    self.mode = mode
+    self.allowedFunctionNames = allowedFunctionNames
+  }
 }
 
 /// Tool configuration for any `Tool` specified in the request.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct ToolConfig: Encodable {
-  let functionCallingConfig: FunctionCallingConfig
+  let functionCallingConfig: FunctionCallingConfig?
 
-  public init(mode: Mode = .auto) {
-    functionCallingConfig = FunctionCallingConfig(mode: mode)
+  public init(functionCallingConfig: FunctionCallingConfig? = nil) {
+    self.functionCallingConfig = functionCallingConfig
   }
 }
 

--- a/Sources/GoogleAI/GenerateContentRequest.swift
+++ b/Sources/GoogleAI/GenerateContentRequest.swift
@@ -22,7 +22,7 @@ struct GenerateContentRequest {
   let generationConfig: GenerationConfig?
   let safetySettings: [SafetySetting]?
   let tools: [Tool]?
-  let toolConfig: ToolConfig
+  let toolConfig: ToolConfig?
   let isStreaming: Bool
   let options: RequestOptions
 }

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -37,7 +37,7 @@ public final class GenerativeModel {
   let tools: [Tool]?
 
   // Tool configuration for any `Tool` specified in the request.
-  let toolConfig: ToolConfig
+  let toolConfig: ToolConfig?
 
   /// Configuration parameters for sending requests to the backend.
   let requestOptions: RequestOptions
@@ -58,7 +58,7 @@ public final class GenerativeModel {
                           generationConfig: GenerationConfig? = nil,
                           safetySettings: [SafetySetting]? = nil,
                           tools: [Tool]? = nil,
-                          toolConfig: ToolConfig = ToolConfig(mode: Mode.auto),
+                          toolConfig: ToolConfig? = nil,
                           requestOptions: RequestOptions = RequestOptions()) {
     self.init(
       name: name,
@@ -78,7 +78,7 @@ public final class GenerativeModel {
        generationConfig: GenerationConfig? = nil,
        safetySettings: [SafetySetting]? = nil,
        tools: [Tool]? = nil,
-       toolConfig: ToolConfig = ToolConfig(mode: Mode.auto),
+       toolConfig: ToolConfig? = nil,
        requestOptions: RequestOptions = RequestOptions(),
        urlSession: URLSession) {
     modelResourceName = GenerativeModel.modelResourceName(name: name)


### PR DESCRIPTION
- Made the `toolConfig` and `functionCallingConfig` parameters optional in constructors / ivars
- Added an `allowedFunctionNames` array for use with `Mode.any`