### PR TITLE
Add public API tests for `GenerateContentResponse`

### DIFF
--- a/Sources/GoogleAI/GenerateContentResponse.swift
+++ b/Sources/GoogleAI/GenerateContentResponse.swift
@@ -51,7 +51,7 @@ public struct GenerateContentResponse {
   }
 
   /// Initializer for SwiftUI previews or tests.
-  public init(candidates: [CandidateResponse], promptFeedback: PromptFeedback?) {
+  public init(candidates: [CandidateResponse], promptFeedback: PromptFeedback? = nil) {
     self.candidates = candidates
     self.promptFeedback = promptFeedback
   }

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -149,6 +149,18 @@ final class GoogleGenerativeAITests: XCTestCase {
     _ = genAI.startChat(history: [ModelContent(parts: "abc")])
   }
 
+  // Public API tests for GenerateContentResponse.
+  func generateContentResponseAPI() {
+    let response = GenerateContentResponse(candidates: [])
+
+    let _: [CandidateResponse] = response.candidates
+    let _: PromptFeedback? = response.promptFeedback
+
+    // Computed Properties
+    let _: String? = response.text
+    let _: [FunctionCall] = response.functionCalls
+  }
+
   // Result builder alternative
 
   /*


### PR DESCRIPTION
- Added tests to verify that the expected symbols in `GenerateContentResponse` are public.
- Added default nil value for `promptFeedback` in the `GenerateContentResponse` constructor to align with Vertex AI.
- This is a port of https://github.com/firebase/firebase-ios-sdk/pull/12791.