### PR TITLE
Switch to latest stable Gemini 1.5 Flash model

### DIFF
--- a/Examples/GenerativeAICLI/Sources/GenerateContent.swift
+++ b/Examples/GenerativeAICLI/Sources/GenerateContent.swift
@@ -102,7 +102,7 @@ struct GenerateContent: AsyncParsableCommand {
     if let modelName {
       return modelName
     } else {
-      return "gemini-1.5-flash-latest"
+      return "gemini-1.5-flash"
     }
   }
 }

--- a/Examples/GenerativeAISample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/Examples/GenerativeAISample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.5-flash", apiKey: APIKey.default)
     chat = model.startChat()
   }
 

--- a/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -39,7 +39,7 @@ class FunctionCallingViewModel: ObservableObject {
 
   init() {
     model = GenerativeModel(
-      name: "gemini-1.5-flash-latest",
+      name: "gemini-1.5-flash",
       apiKey: APIKey.default,
       tools: [Tool(functionDeclarations: [
         FunctionDeclaration(

--- a/Examples/GenerativeAISample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/Examples/GenerativeAISample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.5-flash", apiKey: APIKey.default)
   }
 
   func reason() async {

--- a/Examples/GenerativeAISample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/Examples/GenerativeAISample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.5-flash", apiKey: APIKey.default)
   }
 
   func summarize(inputText: String) async {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example, with just a few lines of code, you can access Gemini's multimodal c
 generate text from text-and-image input:
 
 ```swift
-let model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: "YOUR_API_KEY")
+let model = GenerativeModel(name: "gemini-1.5-flash", apiKey: "YOUR_API_KEY")
 let cookieImage = UIImage(...)
 let prompt = "Do these look store-bought or homemade?"
 

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -48,7 +48,7 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to use, for example `"gemini-1.5-pro-latest"`; see
+  ///   - name: The name of the model to use, for example `"gemini-1.5-flash"`; see
   ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.
@@ -83,7 +83,7 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to use, e.g., `"gemini-1.5-pro-latest"`; see
+  ///   - name: The name of the model to use, e.g., `"gemini-1.5-flash"`; see
   ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -34,37 +34,29 @@ final class GoogleGenerativeAITests: XCTestCase {
     let systemInstruction = ModelContent(role: "system", parts: [.text("Talk like a pirate.")])
 
     // Permutations without optional arguments.
-    let _ = GenerativeModel(name: "gemini-1.5-pro-latest", apiKey: "API_KEY")
+    let _ = GenerativeModel(name: "gemini-1.5-flash", apiKey: "API_KEY")
+    let _ = GenerativeModel(name: "gemini-1.5-flash", apiKey: "API_KEY", safetySettings: filters)
+    let _ = GenerativeModel(name: "gemini-1.5-flash", apiKey: "API_KEY", generationConfig: config)
     let _ = GenerativeModel(
-      name: "gemini-1.5-pro-latest",
-      apiKey: "API_KEY",
-      safetySettings: filters
-    )
-    let _ = GenerativeModel(
-      name: "gemini-1.5-pro-latest",
-      apiKey: "API_KEY",
-      generationConfig: config
-    )
-    let _ = GenerativeModel(
-      name: "gemini-1.5-pro-latest",
+      name: "gemini-1.5-flash",
       apiKey: "API_KEY",
       systemInstruction: systemInstruction
     )
 
     let _ = GenerativeModel(
-      name: "gemini-1.5-pro-latest",
+      name: "gemini-1.5-flash",
       apiKey: "API_KEY",
       systemInstruction: "Talk like a pirate."
     )
 
     let _ = GenerativeModel(
-      name: "gemini-1.5-pro-latest",
+      name: "gemini-1.5-flash",
       apiKey: "API_KEY",
       systemInstruction: "Talk like a pirate.", "Your name is Francis Drake."
     )
 
     // All arguments passed.
-    let genAI = GenerativeModel(name: "gemini-1.5-pro-latest",
+    let genAI = GenerativeModel(name: "gemini-1.5-flash",
                                 apiKey: "API_KEY",
                                 generationConfig: config, // Optional
                                 safetySettings: filters, // Optional


### PR DESCRIPTION
Replaced uses of `gemini-1.5-pro-latest` and `gemini-1.5-flash-latest` ([latest versions](https://ai.google.dev/gemini-api/docs/models/gemini#model-versions) -- can be previews) with `gemini-1.5-flash` (latest stable version) in docs and samples.

Note: The current sample apps don't have any `1.5-pro`-specific functionality.