### PR TITLE
Added Google Search support

### DIFF
--- a/Sources/GoogleAI/FunctionCalling.swift
+++ b/Sources/GoogleAI/FunctionCalling.swift
@@ -179,6 +179,7 @@ public struct Tool {
   ///   ``FunctionResponse`` in ``ModelContent/Part/functionResponse(_:)`` with the
   ///   ``ModelContent/role`` "function", providing generation context for the next model turn.
   ///   - codeExecution: Enables the model to execute code as part of generation, if provided.
+  ///   - googleSearch: Enables the Google Search.
   public init(functionDeclarations: [FunctionDeclaration]? = nil,
               codeExecution: CodeExecution? = nil,
               googleSearch: GoogleSearch? = nil) {

--- a/Sources/GoogleAI/FunctionCalling.swift
+++ b/Sources/GoogleAI/FunctionCalling.swift
@@ -164,6 +164,9 @@ public struct Tool {
   /// Enables the model to execute code as part of generation.
   let codeExecution: CodeExecution?
 
+  /// Enables the Google Search
+  let googleSearch: GoogleSearch?
+
   /// Constructs a new `Tool`.
   ///
   /// - Parameters:
@@ -177,9 +180,11 @@ public struct Tool {
   ///   ``ModelContent/role`` "function", providing generation context for the next model turn.
   ///   - codeExecution: Enables the model to execute code as part of generation, if provided.
   public init(functionDeclarations: [FunctionDeclaration]? = nil,
-              codeExecution: CodeExecution? = nil) {
+              codeExecution: CodeExecution? = nil,
+              googleSearch: GoogleSearch? = nil) {
     self.functionDeclarations = functionDeclarations
     self.codeExecution = codeExecution
+    self.googleSearch = googleSearch
   }
 }
 
@@ -256,6 +261,12 @@ public struct FunctionResponse: Equatable {
 /// generated when using this tool.
 public struct CodeExecution {
   /// Constructs a new `CodeExecution` tool.
+  public init() {}
+}
+
+/// Tool for grounding with Google Search
+public struct GoogleSearch {
+  /// Constructs a new `GoogleSearch` tool.
   public init() {}
 }
 
@@ -350,6 +361,8 @@ extension ToolConfig: Encodable {}
 extension FunctionResponse: Encodable {}
 
 extension CodeExecution: Encodable {}
+
+extension GoogleSearch: Encodable {}
 
 extension ExecutableCode: Codable {}
 


### PR DESCRIPTION
## Description of the change
Add support for the Grounding with Google Search feature.  Added google_search tool for Google Search enabling
<img width="674" alt="image" src="https://github.com/user-attachments/assets/3bd64a49-6850-4e1f-8c12-f707fe87ef78" />


## Motivation
Fix of issue https://github.com/google-gemini/generative-ai-swift/issues/217

## Type of change
Feature request

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
