### PR TITLE
Added Image Generation support

### DIFF
--- a/Sources/GoogleAI/GenerateContentResponse.swift
+++ b/Sources/GoogleAI/GenerateContentResponse.swift
@@ -162,6 +162,9 @@ public enum FinishReason: String {
   /// NOTE: When streaming, the Candidate.content will be empty if content filters blocked the
   /// output.
   case safety = "SAFETY"
+    
+  /// The token generation was stopped because the response was flagged for image safety reasons.
+  case imageSafety = "IMAGE_SAFETY"
 
   /// The token generation was stopped because the response was flagged for unauthorized citations.
   case recitation = "RECITATION"

--- a/Sources/GoogleAI/GenerationConfig.swift
+++ b/Sources/GoogleAI/GenerationConfig.swift
@@ -76,6 +76,13 @@ public struct GenerationConfig {
   ///   this is limited to `application/json`.
   public let responseSchema: Schema?
 
+  /// Array of output response modalities
+  ///
+  /// Supported modalities:
+  /// - `text`: Text output
+  /// - `image`: Image output
+  public let responseModalities: [String]?
+
   /// Creates a new `GenerationConfig` value.
   ///
   /// - Parameters:
@@ -87,10 +94,11 @@ public struct GenerationConfig {
   ///   - stopSequences: See ``stopSequences``.
   ///   - responseMIMEType: See ``responseMIMEType``.
   ///   - responseSchema: See ``responseSchema``.
+  ///   - responseModalities: See ``responseModalities``.
   public init(temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil,
               candidateCount: Int? = nil, maxOutputTokens: Int? = nil,
               stopSequences: [String]? = nil, responseMIMEType: String? = nil,
-              responseSchema: Schema? = nil) {
+              responseSchema: Schema? = nil, responseModalities: [String]? = nil) {
     // Explicit init because otherwise if we re-arrange the above variables it changes the API
     // surface.
     self.temperature = temperature
@@ -101,6 +109,7 @@ public struct GenerationConfig {
     self.stopSequences = stopSequences
     self.responseMIMEType = responseMIMEType
     self.responseSchema = responseSchema
+    self.responseModalities = responseModalities
   }
 }
 

--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -140,7 +140,7 @@ extension ModelContent.Part: Codable {
   }
 
   enum InlineDataKeys: String, CodingKey {
-    case mimeType = "mimeType"
+    case mimeType
     case bytes = "data"
   }
 

--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -140,7 +140,7 @@ extension ModelContent.Part: Codable {
   }
 
   enum InlineDataKeys: String, CodingKey {
-    case mimeType = "mime_type"
+    case mimeType = "mimeType"
     case bytes = "data"
   }
 


### PR DESCRIPTION
## Description of the change
Add support for the Gemini Image Generation  
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/672d7eb4-9175-4daa-b1c0-dbdc5a2a4946" />

Also fixed `mime_type` to `mimeType` for `inlineData` response field

## Motivation
Fix of issue https://github.com/google-gemini/generative-ai-swift/issues/220

## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
